### PR TITLE
Refactor uint types

### DIFF
--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -64,7 +64,7 @@ pub fn benchmark_signature_scheme<S: SignatureScheme>(c: &mut Criterion, descrip
             rng.fill(&mut message);
 
             // Sample random epoch
-            let epoch = rng.gen_range(0..S::LIFETIME) as u64;
+            let epoch = rng.gen_range(0..S::LIFETIME) as u32;
 
             // Benchmark signing
             let _ = S::sign(
@@ -77,11 +77,11 @@ pub fn benchmark_signature_scheme<S: SignatureScheme>(c: &mut Criterion, descrip
     });
 
     // Pre-generate messages, epochs, and signatures for verification
-    let precomputed: Vec<(u64, [u8; MESSAGE_LENGTH], S::Signature)> = (0..2000)
+    let precomputed: Vec<(u32, [u8; MESSAGE_LENGTH], S::Signature)> = (0..2000)
         .map(|_| {
             let mut message = [0u8; MESSAGE_LENGTH];
             rng.fill(&mut message);
-            let epoch = rng.gen_range(0..S::LIFETIME) as u64;
+            let epoch = rng.gen_range(0..S::LIFETIME) as u32;
             let signature =
                 S::sign(&mut rng, &sk, epoch, &message).expect("Signing should succeed");
             (epoch, message, signature)

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -214,6 +214,5 @@ fn bench_function(c: &mut Criterion) {
     bench_lifetime20_target_sum(c);
 }
 
-
 criterion_group!(benches, bench_function);
 criterion_main!(benches);

--- a/src/inc_encoding.rs
+++ b/src/inc_encoding.rs
@@ -41,7 +41,7 @@ pub trait IncomparableEncoding {
         message: &[u8; MESSAGE_LENGTH],
         randomness: &Self::Randomness,
         epoch: u32,
-    ) -> Result<Vec<u64>, EncodingError>;
+    ) -> Result<Vec<u32>, EncodingError>;
 }
 
 pub mod basic_winternitz;

--- a/src/inc_encoding.rs
+++ b/src/inc_encoding.rs
@@ -40,7 +40,7 @@ pub trait IncomparableEncoding {
         parameter: &Self::Parameter,
         message: &[u8; MESSAGE_LENGTH],
         randomness: &Self::Randomness,
-        epoch: u64,
+        epoch: u32,
     ) -> Result<Vec<u64>, EncodingError>;
 }
 

--- a/src/inc_encoding/basic_winternitz.rs
+++ b/src/inc_encoding/basic_winternitz.rs
@@ -12,11 +12,12 @@ use super::IncomparableEncoding;
 /// Unfortunately, Rust cannot deal with logarithms and ceils in constants.
 /// Therefore, the user needs to supply NUM_CHUNKS_CHECKSUM. This value can
 /// be computed before compilation with the following steps:
-///
+/// ```ignore
 ///     base = 2 ** chunk_size
 ///     num_chunks_message = MH::OUTPUT_LENGTH * 8 / chunk_size
 ///     max_checksum = num_chunks_message * (base - 1)
 ///     num_chunks_checksum = 1 + math.floor(math.log(max_checksum, base))
+/// ```
 
 pub struct WinternitzEncoding<
     MH: MessageHash,

--- a/src/inc_encoding/basic_winternitz.rs
+++ b/src/inc_encoding/basic_winternitz.rs
@@ -56,7 +56,7 @@ impl<MH: MessageHash, const CHUNK_SIZE: usize, const NUM_CHUNKS_CHECKSUM: usize>
         parameter: &Self::Parameter,
         message: &[u8; MESSAGE_LENGTH],
         randomness: &Self::Randomness,
-        epoch: u64,
+        epoch: u32,
     ) -> Result<Vec<u64>, super::EncodingError> {
         // apply the message hash first, get bytes, and then convert into chunks
         let hash_bytes = MH::apply(parameter, epoch, randomness, message);

--- a/src/inc_encoding/basic_winternitz.rs
+++ b/src/inc_encoding/basic_winternitz.rs
@@ -57,7 +57,7 @@ impl<MH: MessageHash, const CHUNK_SIZE: usize, const NUM_CHUNKS_CHECKSUM: usize>
         message: &[u8; MESSAGE_LENGTH],
         randomness: &Self::Randomness,
         epoch: u32,
-    ) -> Result<Vec<u64>, super::EncodingError> {
+    ) -> Result<Vec<u32>, super::EncodingError> {
         // apply the message hash first, get bytes, and then convert into chunks
         let hash_bytes = MH::apply(parameter, epoch, randomness, message);
         let chunks_message: Vec<u8> = bytes_to_chunks(&hash_bytes, Self::CHUNK_SIZE);
@@ -79,7 +79,7 @@ impl<MH: MessageHash, const CHUNK_SIZE: usize, const NUM_CHUNKS_CHECKSUM: usize>
         let mut chunks = Vec::with_capacity(chunks_message.len() + NUM_CHUNKS_CHECKSUM);
         chunks.extend_from_slice(&chunks_message);
         chunks.extend_from_slice(&chunks_checksum[..NUM_CHUNKS_CHECKSUM]);
-        let chunks_u64: Vec<u64> = chunks.iter().map(|&x| x as u64).collect();
-        Ok(chunks_u64)
+        let chunks_u32: Vec<u32> = chunks.iter().map(|&x| x as u32).collect();
+        Ok(chunks_u32)
     }
 }

--- a/src/inc_encoding/target_sum.rs
+++ b/src/inc_encoding/target_sum.rs
@@ -51,18 +51,18 @@ impl<MH: MessageHash, const CHUNK_SIZE: usize, const TARGET_SUM: usize> Incompar
         message: &[u8; 64],
         randomness: &Self::Randomness,
         epoch: u32,
-    ) -> Result<Vec<u64>, super::EncodingError> {
+    ) -> Result<Vec<u32>, super::EncodingError> {
         // apply the message hash first, get bytes
         let hash_bytes = MH::apply(parameter, epoch, randomness, message);
         // convert the bytes into chunks
         let chunks: Vec<u8> = bytes_to_chunks(&hash_bytes, Self::CHUNK_SIZE);
-        let chunks_u64: Vec<u64> = chunks.iter().map(|&x| x as u64).collect();
-        let sum: u64 = chunks_u64.iter().sum();
+        let chunks_u32: Vec<u32> = chunks.iter().map(|&x| x as u32).collect();
+        let sum: u32 = chunks_u32.iter().sum();
         // only output the chunks sum to the target sum
         return if sum as usize != Self::TARGET_SUM {
             Err(())
         } else {
-            Ok(chunks_u64)
+            Ok(chunks_u32)
         };
     }
 }

--- a/src/inc_encoding/target_sum.rs
+++ b/src/inc_encoding/target_sum.rs
@@ -50,7 +50,7 @@ impl<MH: MessageHash, const CHUNK_SIZE: usize, const TARGET_SUM: usize> Incompar
         parameter: &Self::Parameter,
         message: &[u8; 64],
         randomness: &Self::Randomness,
-        epoch: u64,
+        epoch: u32,
     ) -> Result<Vec<u64>, super::EncodingError> {
         // apply the message hash first, get bytes
         let hash_bytes = MH::apply(parameter, epoch, randomness, message);

--- a/src/inc_encoding/target_sum.rs
+++ b/src/inc_encoding/target_sum.rs
@@ -10,10 +10,11 @@ use super::IncomparableEncoding;
 /// or equivalently the success probability of this encoding scheme.
 /// It is recommended to set it close to the expected sum, which is:
 ///
-///     const NUM_CHUNKS: usize = MH::OUTPUT_LENGTH * 8 / CHUNK_SIZE;
-///     const MAX_CHUNK_VALUE: usize = (1 << CHUNK_SIZE) - 1;
-///     const EXPECTED_SUM: usize = Self::NUM_CHUNKS * Self::MAX_CHUNK_VALUE / 2;
-///
+/// ```ignore
+///     const NUM_CHUNKS: usize = MH::OUTPUT_LENGTH * 8 / CHUNK_SIZE
+///     const MAX_CHUNK_VALUE: usize = (1 << CHUNK_SIZE) - 1
+///     const EXPECTED_SUM: usize = Self::NUM_CHUNKS * Self::MAX_CHUNK_VALUE / 2
+/// ```
 pub struct TargetSumEncoding<MH: MessageHash, const CHUNK_SIZE: usize, const TARGET_SUM: usize> {
     _marker_mh: std::marker::PhantomData<MH>,
 }

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -19,7 +19,7 @@ pub trait SignatureScheme {
 
     /// number of epochs that are supported
     /// with one key. Must be a power of two.
-    const LIFETIME: usize;
+    const LIFETIME: u64;
 
     /// Generates a new key pair, returning the public and private keys.
     fn gen<R: Rng>(rng: &mut R) -> (Self::PublicKey, Self::SecretKey);
@@ -29,14 +29,14 @@ pub trait SignatureScheme {
     fn sign<R: Rng>(
         rng: &mut R,
         sk: &Self::SecretKey,
-        epoch: u64,
+        epoch: u32,
         message: &[u8; MESSAGE_LENGTH],
     ) -> Result<Self::Signature, SigningError>;
 
     /// Verifies a signature with respect to public key, epoch, and message digest.
     fn verify(
         pk: &Self::PublicKey,
-        epoch: u64,
+        epoch: u32,
         message: &[u8; MESSAGE_LENGTH],
         sig: &Self::Signature,
     ) -> bool;
@@ -53,7 +53,7 @@ mod test_templates {
     /// Generic test for any implementation of the `SignatureScheme` trait.
     /// Tests correctness, i.e., that honest key gen, honest signing, implies
     /// that the verifier accepts the signature. A random message is used.
-    pub fn _test_signature_scheme_correctness<T: SignatureScheme>(epoch: u64) {
+    pub fn _test_signature_scheme_correctness<T: SignatureScheme>(epoch: u32) {
         let mut rng = thread_rng();
 
         // Generate a key pair

--- a/src/signature/generalized_xmss.rs
+++ b/src/signature/generalized_xmss.rs
@@ -110,7 +110,7 @@ where
                 let end = chain::<TH>(
                     &parameter,
                     epoch as u32,
-                    chain_index as u64,
+                    chain_index as u32,
                     0,
                     chain_length - 1,
                     &start,
@@ -205,7 +205,7 @@ where
             let hash_in_chain = chain::<TH>(
                 &sk.parameter,
                 epoch,
-                chain_index as u64,
+                chain_index as u32,
                 0,
                 steps as usize,
                 &start,
@@ -254,7 +254,7 @@ where
             let end = chain::<TH>(
                 &pk.parameter,
                 epoch,
-                chain_index as u64,
+                chain_index as u32,
                 start_pos_in_chain,
                 steps as usize,
                 start,

--- a/src/symmetric/message_hash.rs
+++ b/src/symmetric/message_hash.rs
@@ -24,7 +24,7 @@ pub trait MessageHash {
     /// use the function `bytes_to_chunks`.
     fn apply(
         parameter: &Self::Parameter,
-        epoch: u64,
+        epoch: u32,
         randomness: &Self::Randomness,
         message: &[u8; MESSAGE_LENGTH],
     ) -> Vec<u8>;

--- a/src/symmetric/message_hash/sha.rs
+++ b/src/symmetric/message_hash/sha.rs
@@ -31,7 +31,7 @@ impl<const PARAMETER_LEN: usize, const RAND_LEN: usize, const MESSAGE_HASH_LEN: 
 
     fn apply(
         parameter: &Self::Parameter,
-        epoch: u64,
+        epoch: u32,
         randomness: &Self::Randomness,
         message: &[u8; MESSAGE_LENGTH],
     ) -> Vec<u8> {

--- a/src/symmetric/prf.rs
+++ b/src/symmetric/prf.rs
@@ -9,7 +9,7 @@ pub trait Pseudorandom {
     fn gen<R: Rng>(rng: &mut R) -> Self::Key;
 
     /// Apply the one-way function to an epoch and an index
-    fn apply(key: &Self::Key, epoch: u64, index: u64) -> Self::Output;
+    fn apply(key: &Self::Key, epoch: u32, index: u64) -> Self::Output;
 }
 
 pub mod hashprf;

--- a/src/symmetric/prf/hashprf.rs
+++ b/src/symmetric/prf/hashprf.rs
@@ -20,7 +20,7 @@ impl<const OUTPUT_LENGTH: usize> Pseudorandom for Sha256PRF<OUTPUT_LENGTH> {
         key
     }
 
-    fn apply(key: &Self::Key, epoch: u64, index: u64) -> Self::Output {
+    fn apply(key: &Self::Key, epoch: u32, index: u64) -> Self::Output {
         assert!(
             OUTPUT_LENGTH < 256 / 8,
             "SHA256-PRF: Output length must be less than 256 bit"
@@ -40,7 +40,7 @@ impl<const OUTPUT_LENGTH: usize> Pseudorandom for Sha256PRF<OUTPUT_LENGTH> {
         // Hash the index
         hasher.update(index.to_be_bytes());
 
-        // Finalize and convert the first 8 bytes to u64
+        // Finalize and convert to output
         let result = hasher.finalize();
         result[0..OUTPUT_LENGTH].try_into().unwrap()
     }

--- a/src/symmetric/tweak_hash.rs
+++ b/src/symmetric/tweak_hash.rs
@@ -29,7 +29,7 @@ pub trait TweakableHash {
 
     /// Returns a tweak to be used in chains.
     /// Note: this is assumed to be distinct from the outputs of tree_tweak
-    fn chain_tweak(epoch: u32, chain_index: u64, pos_in_chain: u64) -> Self::Tweak;
+    fn chain_tweak(epoch: u32, chain_index: u32, pos_in_chain: u32) -> Self::Tweak;
 
     /// Applies the tweakable hash to parameter, tweak, and message.
     fn apply(
@@ -49,8 +49,8 @@ pub trait TweakableHash {
 pub(crate) fn chain<TH: TweakableHash>(
     parameter: &TH::Parameter,
     epoch: u32,
-    chain_index: u64,
-    start_pos_in_chain: u64,
+    chain_index: u32,
+    start_pos_in_chain: u32,
     steps: usize,
     start: &TH::Domain,
 ) -> TH::Domain {
@@ -59,7 +59,7 @@ pub(crate) fn chain<TH: TweakableHash>(
 
     // otherwise, walk the right amount of steps
     for j in 0..steps {
-        let tweak = TH::chain_tweak(epoch, chain_index, start_pos_in_chain + (j as u64) + 1);
+        let tweak = TH::chain_tweak(epoch, chain_index, start_pos_in_chain + (j as u32) + 1);
         current = TH::apply(parameter, &tweak, &[current]);
     }
 
@@ -104,7 +104,7 @@ mod tests {
                 &parameter,
                 epoch,
                 chain_index,
-                steps_a as u64,
+                steps_a as u32,
                 steps_b,
                 &intermediate,
             );

--- a/src/symmetric/tweak_hash.rs
+++ b/src/symmetric/tweak_hash.rs
@@ -25,7 +25,7 @@ pub trait TweakableHash {
 
     /// Returns a tweak to be used in the Merkle tree.
     /// Note: this is assumed to be distinct from the outputs of chain_tweak
-    fn tree_tweak(level: u64, pos_in_level: u64) -> Self::Tweak;
+    fn tree_tweak(level: u8, pos_in_level: u64) -> Self::Tweak;
 
     /// Returns a tweak to be used in chains.
     /// Note: this is assumed to be distinct from the outputs of tree_tweak

--- a/src/symmetric/tweak_hash.rs
+++ b/src/symmetric/tweak_hash.rs
@@ -25,11 +25,11 @@ pub trait TweakableHash {
 
     /// Returns a tweak to be used in the Merkle tree.
     /// Note: this is assumed to be distinct from the outputs of chain_tweak
-    fn tree_tweak(level: u8, pos_in_level: u64) -> Self::Tweak;
+    fn tree_tweak(level: u8, pos_in_level: u32) -> Self::Tweak;
 
     /// Returns a tweak to be used in chains.
     /// Note: this is assumed to be distinct from the outputs of tree_tweak
-    fn chain_tweak(epoch: u64, chain_index: u64, pos_in_chain: u64) -> Self::Tweak;
+    fn chain_tweak(epoch: u32, chain_index: u64, pos_in_chain: u64) -> Self::Tweak;
 
     /// Applies the tweakable hash to parameter, tweak, and message.
     fn apply(
@@ -48,7 +48,7 @@ pub trait TweakableHash {
 /// with `start = A` would mean we walk A -> B -> C, and then return C.
 pub(crate) fn chain<TH: TweakableHash>(
     parameter: &TH::Parameter,
-    epoch: u64,
+    epoch: u32,
     chain_index: u64,
     start_pos_in_chain: u64,
     steps: usize,

--- a/src/symmetric/tweak_hash/sha.rs
+++ b/src/symmetric/tweak_hash/sha.rs
@@ -10,8 +10,8 @@ pub enum Sha256Tweak {
     },
     ChainTweak {
         epoch: u32,
-        chain_index: u64,
-        pos_in_chain: u64,
+        chain_index: u32,
+        pos_in_chain: u32,
     },
 }
 
@@ -28,8 +28,8 @@ impl Sha256Tweak {
                 // then we extend with the actual data
                 bytes.extend(&level.to_be_bytes());
                 bytes.extend(&pos_in_level.to_be_bytes());
-                // and finally a 64 0-bits to ensure the same length
-                bytes.extend_from_slice(&[0; 8]);
+                // and finally a 7 0-bytes to ensure the same length
+                bytes.extend_from_slice(&[0; 7]);
                 bytes
             }
             Sha256Tweak::ChainTweak {
@@ -84,7 +84,7 @@ impl<const PARAMETER_LEN: usize, const HASH_LEN: usize> TweakableHash
         }
     }
 
-    fn chain_tweak(epoch: u32, chain_index: u64, pos_in_chain: u64) -> Self::Tweak {
+    fn chain_tweak(epoch: u32, chain_index: u32, pos_in_chain: u32) -> Self::Tweak {
         Sha256Tweak::ChainTweak {
             epoch,
             chain_index,

--- a/src/symmetric/tweak_hash/sha.rs
+++ b/src/symmetric/tweak_hash/sha.rs
@@ -5,7 +5,7 @@ use super::TweakableHash;
 /// Enum to implement tweaks.
 pub enum Sha256Tweak {
     TreeTweak {
-        level: u64,
+        level: u8,
         pos_in_level: u64,
     },
     ChainTweak {
@@ -77,7 +77,7 @@ impl<const PARAMETER_LEN: usize, const HASH_LEN: usize> TweakableHash
         dom
     }
 
-    fn tree_tweak(level: u64, pos_in_level: u64) -> Self::Tweak {
+    fn tree_tweak(level: u8, pos_in_level: u64) -> Self::Tweak {
         Sha256Tweak::TreeTweak {
             level,
             pos_in_level,

--- a/src/symmetric/tweak_hash/sha.rs
+++ b/src/symmetric/tweak_hash/sha.rs
@@ -6,10 +6,10 @@ use super::TweakableHash;
 pub enum Sha256Tweak {
     TreeTweak {
         level: u8,
-        pos_in_level: u64,
+        pos_in_level: u32,
     },
     ChainTweak {
-        epoch: u64,
+        epoch: u32,
         chain_index: u64,
         pos_in_chain: u64,
     },
@@ -77,14 +77,14 @@ impl<const PARAMETER_LEN: usize, const HASH_LEN: usize> TweakableHash
         dom
     }
 
-    fn tree_tweak(level: u8, pos_in_level: u64) -> Self::Tweak {
+    fn tree_tweak(level: u8, pos_in_level: u32) -> Self::Tweak {
         Sha256Tweak::TreeTweak {
             level,
             pos_in_level,
         }
     }
 
-    fn chain_tweak(epoch: u64, chain_index: u64, pos_in_chain: u64) -> Self::Tweak {
+    fn chain_tweak(epoch: u32, chain_index: u64, pos_in_chain: u64) -> Self::Tweak {
         Sha256Tweak::ChainTweak {
             epoch,
             chain_index,

--- a/src/symmetric/tweak_hash_tree.rs
+++ b/src/symmetric/tweak_hash_tree.rs
@@ -34,7 +34,7 @@ pub fn build_tree<TH: TweakableHash>(
     }
 
     // now, we build each layer by hashing pairs in the previous layer
-    let mut level = 1;
+    let mut level: u8 = 1;
     while layer_size >= 2 {
         // start a new layer
         layers.push(Vec::new());
@@ -90,9 +90,15 @@ pub fn hash_tree_path<TH: TweakableHash>(
         "Hash-Tree hash tree path: Invalid position"
     );
 
+    let depth = tree.layers.len() - 1;
+
+    assert!(
+        depth <= 64,
+        "Hash-Tree hash tree path: Tree depth must be at most 64"
+    );
+
     // in our co-path, we will have one node per layer
     // except the final layer (which is just the root)
-    let depth = tree.layers.len() - 1;
     let mut co_path: Vec<TH::Domain> = Vec::with_capacity(depth);
     let mut current_position = position;
     for l in 0..depth {
@@ -122,6 +128,12 @@ pub fn hash_tree_verify<TH: TweakableHash>(
     // position makes sense.
     let depth = opening.co_path.len();
     let num_leafs: u64 = 1 << depth;
+
+    assert!(
+        depth <= 64,
+        "Hash-Tree hash tree verify: Tree depth must be at most 64"
+    );
+
     assert!(
         position < num_leafs,
         "Hash-Tree hash tree verify: Position and Path Length not compatible"
@@ -148,7 +160,7 @@ pub fn hash_tree_verify<TH: TweakableHash>(
         current_position = current_position >> 1;
 
         // now hash to get the parent
-        let tweak = TH::tree_tweak((l + 1) as u64, current_position);
+        let tweak = TH::tree_tweak((l + 1) as u8, current_position);
         current_node = TH::apply(parameter, &tweak, &children);
     }
 

--- a/src/symmetric/tweak_hash_tree.rs
+++ b/src/symmetric/tweak_hash_tree.rs
@@ -28,7 +28,7 @@ pub fn build_tree<TH: TweakableHash>(
     // the bottom layer contains the individual hashes of all leafs
     layers.push(Vec::new());
     for i in 0..layer_size {
-        let tweak = TH::tree_tweak(0, i as u64);
+        let tweak = TH::tree_tweak(0, i as u32);
         let hash = TH::apply(parameter, &tweak, leafs[i]);
         layers[0].push(hash);
     }
@@ -43,7 +43,7 @@ pub fn build_tree<TH: TweakableHash>(
         for i in 0..layer_size {
             let left_idx = 2 * i;
             let right_idx = 2 * i + 1;
-            let tweak = TH::tree_tweak(level, i as u64);
+            let tweak = TH::tree_tweak(level, i as u32);
             let children = &layers[(level - 1) as usize][left_idx..=right_idx];
             let parent = TH::apply(parameter, &tweak, children);
             layers[level as usize].push(parent);
@@ -79,14 +79,14 @@ pub struct HashTreeOpening<TH: TweakableHash> {
 /// size 1.
 pub fn hash_tree_path<TH: TweakableHash>(
     tree: &HashTree<TH>,
-    position: u64,
+    position: u32,
 ) -> HashTreeOpening<TH> {
     assert!(
         !tree.layers.is_empty(),
         "Hash-Tree hash tree path: Need at least one layer"
     );
     assert!(
-        position < tree.layers[0].len() as u64,
+        (position as u64) < (tree.layers[0].len() as u64),
         "Hash-Tree hash tree path: Invalid position"
     );
 
@@ -119,7 +119,7 @@ pub fn hash_tree_path<TH: TweakableHash>(
 pub fn hash_tree_verify<TH: TweakableHash>(
     parameter: &TH::Parameter,
     root: &TH::Domain,
-    position: u64,
+    position: u32,
     leaf: &[TH::Domain],
     opening: &HashTreeOpening<TH>,
 ) -> bool {
@@ -135,7 +135,7 @@ pub fn hash_tree_verify<TH: TweakableHash>(
     );
 
     assert!(
-        position < num_leafs,
+        (position as u64) < num_leafs,
         "Hash-Tree hash tree verify: Position and Path Length not compatible"
     );
 


### PR DESCRIPTION
This PR changes certain types of epochs, chain indices, positions in Merkle trees, etc.
Previously, all of that was u64. As this was not necessary (e.g., we will never have 2^64 epochs), 
we use smaller types now, which also improves efficiency.