### PR TITLE
Poseidon implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 rand = "0.8.5"
 sha2 = "0.10.8"
+zkhash = { git = "https://github.com/HorizenLabs/poseidon2", branch = "main", package = "zkhash" }
 
 [dev-dependencies]
 criterion = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 rand = "0.8.5"
 sha2 = "0.10.8"
 zkhash = { git = "https://github.com/HorizenLabs/poseidon2", branch = "main", package = "zkhash" }
+num-bigint = "0.4.6"
 
 [dev-dependencies]
 criterion = "0.4"

--- a/src/inc_encoding.rs
+++ b/src/inc_encoding.rs
@@ -41,7 +41,7 @@ pub trait IncomparableEncoding {
         message: &[u8; MESSAGE_LENGTH],
         randomness: &Self::Randomness,
         epoch: u32,
-    ) -> Result<Vec<u32>, EncodingError>;
+    ) -> Result<Vec<u16>, EncodingError>;
 }
 
 pub mod basic_winternitz;

--- a/src/inc_encoding/basic_winternitz.rs
+++ b/src/inc_encoding/basic_winternitz.rs
@@ -53,7 +53,7 @@ impl<MH: MessageHash, const NUM_CHUNKS_CHECKSUM: usize> IncomparableEncoding
         message: &[u8; MESSAGE_LENGTH],
         randomness: &Self::Randomness,
         epoch: u32,
-    ) -> Result<Vec<u32>, super::EncodingError> {
+    ) -> Result<Vec<u16>, super::EncodingError> {
         // apply the message hash to get chunks
         let chunks_message = MH::apply(parameter, epoch, randomness, message);
 
@@ -74,7 +74,7 @@ impl<MH: MessageHash, const NUM_CHUNKS_CHECKSUM: usize> IncomparableEncoding
         let mut chunks = Vec::with_capacity(chunks_message.len() + NUM_CHUNKS_CHECKSUM);
         chunks.extend_from_slice(&chunks_message);
         chunks.extend_from_slice(&chunks_checksum[..NUM_CHUNKS_CHECKSUM]);
-        let chunks_u32: Vec<u32> = chunks.iter().map(|&x| x as u32).collect();
+        let chunks_u32: Vec<u16> = chunks.iter().map(|&x| x as u16).collect();
         Ok(chunks_u32)
     }
 }

--- a/src/inc_encoding/basic_winternitz.rs
+++ b/src/inc_encoding/basic_winternitz.rs
@@ -74,7 +74,7 @@ impl<MH: MessageHash, const NUM_CHUNKS_CHECKSUM: usize> IncomparableEncoding
         let mut chunks = Vec::with_capacity(chunks_message.len() + NUM_CHUNKS_CHECKSUM);
         chunks.extend_from_slice(&chunks_message);
         chunks.extend_from_slice(&chunks_checksum[..NUM_CHUNKS_CHECKSUM]);
-        let chunks_u32: Vec<u16> = chunks.iter().map(|&x| x as u16).collect();
-        Ok(chunks_u32)
+        let chunks_u16: Vec<u16> = chunks.iter().map(|&x| x as u16).collect();
+        Ok(chunks_u16)
     }
 }

--- a/src/inc_encoding/target_sum.rs
+++ b/src/inc_encoding/target_sum.rs
@@ -1,4 +1,4 @@
-use crate::symmetric::message_hash::MessageHash;
+use crate::{symmetric::message_hash::MessageHash, MESSAGE_LENGTH};
 
 use super::IncomparableEncoding;
 
@@ -45,19 +45,21 @@ impl<MH: MessageHash, const TARGET_SUM: usize> IncomparableEncoding
 
     fn encode(
         parameter: &Self::Parameter,
-        message: &[u8; 64],
+        message: &[u8; MESSAGE_LENGTH],
         randomness: &Self::Randomness,
         epoch: u32,
-    ) -> Result<Vec<u32>, super::EncodingError> {
+    ) -> Result<Vec<u16>, super::EncodingError> {
         // apply the message hash first to get chunks
         let chunks = MH::apply(parameter, epoch, randomness, message);
+        let chunks_u16: Vec<u16> = chunks.iter().map(|&x| x as u16).collect();
         let chunks_u32: Vec<u32> = chunks.iter().map(|&x| x as u32).collect();
+
         let sum: u32 = chunks_u32.iter().sum();
         // only output the chunks sum to the target sum
         return if sum as usize != Self::TARGET_SUM {
             Err(())
         } else {
-            Ok(chunks_u32)
+            Ok(chunks_u16)
         };
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,9 @@
 /// Message length in bytes, for messages
 /// that we want to sign.
-pub const MESSAGE_LENGTH: usize = 64;
+pub const MESSAGE_LENGTH: usize = 32;
 pub const TWEAK_SEPARATOR_FOR_MESSAGE_HASH: u8 = 2;
+pub const TWEAK_SEPARATOR_FOR_TREE_HASH: u8 = 1;
+pub const TWEAK_SEPARATOR_FOR_CHAIN_HASH: u8 = 0;
 
 pub mod inc_encoding;
 pub mod signature;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 /// Message length in bytes, for messages
 /// that we want to sign.
 pub const MESSAGE_LENGTH: usize = 64;
+pub const TWEAK_SEPARATOR_FOR_MESSAGE_HASH: u8 = 2;
 
 pub mod inc_encoding;
 pub mod signature;

--- a/src/signature/generalized_xmss.rs
+++ b/src/signature/generalized_xmss.rs
@@ -110,7 +110,7 @@ where
                 let end = chain::<TH>(
                     &parameter,
                     epoch as u32,
-                    chain_index as u32,
+                    chain_index as u16,
                     0,
                     chain_length - 1,
                     &start,
@@ -147,7 +147,7 @@ where
         rng: &mut R,
         sk: &Self::SecretKey,
         epoch: u32,
-        message: &[u8; 64],
+        message: &[u8; MESSAGE_LENGTH],
     ) -> Result<Self::Signature, SigningError> {
         // check first that we have the correct message length
         if message.len() != MESSAGE_LENGTH {
@@ -205,7 +205,7 @@ where
             let hash_in_chain = chain::<TH>(
                 &sk.parameter,
                 epoch,
-                chain_index as u32,
+                chain_index as u16,
                 0,
                 steps as usize,
                 &start,
@@ -254,7 +254,7 @@ where
             let end = chain::<TH>(
                 &pk.parameter,
                 epoch,
-                chain_index as u32,
+                chain_index as u16,
                 start_pos_in_chain,
                 steps as usize,
                 start,

--- a/src/symmetric/message_hash.rs
+++ b/src/symmetric/message_hash.rs
@@ -32,6 +32,7 @@ pub trait MessageHash {
     ) -> Vec<u8>;
 }
 
+pub mod poseidon;
 pub mod sha;
 
 /// Isolates a chunk of bits from a byte based on the specified chunk index and chunk size.

--- a/src/symmetric/message_hash.rs
+++ b/src/symmetric/message_hash.rs
@@ -30,6 +30,10 @@ pub trait MessageHash {
         randomness: &Self::Randomness,
         message: &[u8; MESSAGE_LENGTH],
     ) -> Vec<u8>;
+
+    /// Check that the parameters are sound and internally consistent
+    /// Panics if smth is wrong
+    fn consistency_check();
 }
 
 pub mod poseidon;

--- a/src/symmetric/message_hash/poseidon.rs
+++ b/src/symmetric/message_hash/poseidon.rs
@@ -1,0 +1,137 @@
+use zkhash::ark_ff::One;
+use zkhash::ark_ff::UniformRand;
+use zkhash::fields::babybear::FpBabyBear;
+use zkhash::poseidon2::poseidon2::Poseidon2;
+use zkhash::poseidon2::poseidon2_instance_babybear::POSEIDON2_BABYBEAR_24_PARAMS;
+
+use crate::symmetric::tweak_hash::poseidon::poseidon_compress;
+use crate::MESSAGE_LENGTH;
+
+use super::MessageHash;
+
+// TODO: Check if we want to use this field or a different one
+type F = FpBabyBear;
+
+/// Function to encode a message as a vector of field elements
+fn encode_message(message: &[u8; MESSAGE_LENGTH]) -> Vec<F> {
+    // TODO: this needs to be implemented properly
+    vec![]
+}
+
+/// Function to encode an epoch (= tweak in the message hash)
+/// as a vector of field elements.
+fn encode_epoch(epoch: u32) -> Vec<F> {
+    // TODO: this needs to be implemented properly
+    vec![]
+}
+
+/// Function to decode a vector of field elements into
+/// a vector of NUM_CHUNKS many chunks. One chunk is
+/// between 0 and 2^CHUNK_SIZE - 1 (inclusive).
+fn decode_to_chunks<const NUM_CHUNKS: usize, const CHUNK_SIZE: usize, const HASH_LEN_FE: usize>(
+    field_elements: &[F],
+) -> Vec<u8> {
+    // TODO: this needs to be implemented properly
+    vec![]
+}
+
+/// A message hash implemented using Poseidon2
+///
+/// Note: PARAMETER_LEN, RAND_LEN, and HASH_LEN_FE
+/// must be given in the unit "number of field elements".
+///
+/// HASH_LEN_FE specifies how many field elements the
+/// hash output needs to be before it is decoded to chunks.
+///
+/// CHUNK_SIZE has to be 1,2,4, or 8.
+pub struct PoseidonMessageHash<
+    const PARAMETER_LEN: usize,
+    const RAND_LEN: usize,
+    const HASH_LEN_FE: usize,
+    const NUM_CHUNKS: usize,
+    const CHUNK_SIZE: usize,
+>;
+
+impl<
+        const PARAMETER_LEN: usize,
+        const RAND_LEN: usize,
+        const HASH_LEN_FE: usize,
+        const NUM_CHUNKS: usize,
+        const CHUNK_SIZE: usize,
+    > MessageHash
+    for PoseidonMessageHash<PARAMETER_LEN, RAND_LEN, HASH_LEN_FE, NUM_CHUNKS, CHUNK_SIZE>
+{
+    type Parameter = [F; PARAMETER_LEN];
+
+    type Randomness = [F; RAND_LEN];
+
+    const NUM_CHUNKS: usize = NUM_CHUNKS;
+
+    const CHUNK_SIZE: usize = CHUNK_SIZE;
+
+    fn rand<R: rand::Rng>(rng: &mut R) -> Self::Randomness {
+        let mut rnd = [F::one(); RAND_LEN];
+        for i in 0..RAND_LEN {
+            rnd[i] = F::rand(rng);
+        }
+        rnd
+    }
+
+    fn apply(
+        parameter: &Self::Parameter,
+        epoch: u32,
+        randomness: &Self::Randomness,
+        message: &[u8; MESSAGE_LENGTH],
+    ) -> Vec<u8> {
+        // TODO: we should assert that lengths small enough for Poseidon parameters
+
+        // We need a Poseidon instance
+        let instance = Poseidon2::new(&POSEIDON2_BABYBEAR_24_PARAMS);
+
+        // first, encode the message and the epoch as field elements
+        let message_fe = encode_message(message);
+        let epoch_fe = encode_epoch(epoch);
+
+        // now, we hash parameters, epoch, message, randomness using PoseidonCompress
+        let combined_input: Vec<F> = parameter
+            .iter()
+            .chain(epoch_fe.iter())
+            .chain(message_fe.iter())
+            .chain(randomness.iter())
+            .cloned()
+            .collect();
+        let hash_fe = poseidon_compress::<HASH_LEN_FE>(&instance, &combined_input);
+
+        // decode field elements into chunks and return them
+        decode_to_chunks::<NUM_CHUNKS, CHUNK_SIZE, HASH_LEN_FE>(&hash_fe)
+    }
+}
+
+// Example instantiations
+// TODO: check if this instantiation makes any sense
+pub type PoseidonMessageHash445 = PoseidonMessageHash<4, 4, 5, 128, 2>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::{thread_rng, Rng};
+    use zkhash::ark_ff::UniformRand;
+
+    #[test]
+    fn test_apply() {
+        let mut rng = thread_rng();
+
+        let mut parameter = [F::one(); 4];
+        for i in 0..4 {
+            parameter[i] = F::rand(&mut rng);
+        }
+
+        let mut message = [0u8; MESSAGE_LENGTH];
+        rng.fill(&mut message);
+
+        let epoch = 13;
+        let randomness = PoseidonMessageHash445::rand(&mut rng);
+
+        PoseidonMessageHash445::apply(&parameter, epoch, &randomness, &message);
+    }
+}

--- a/src/symmetric/message_hash/poseidon.rs
+++ b/src/symmetric/message_hash/poseidon.rs
@@ -45,7 +45,7 @@ fn encode_epoch<const TWEAK_LEN_FE: usize>(epoch: u32) ->[F;TWEAK_LEN_FE] {
         .to_string()
         .parse()
         .unwrap())*f64::from(TWEAK_LEN_FE as u32);
-    assert!(input_bits<=f64::from((32+8 as u32)), "Parameter mismatch: not enough field elements to encode the epoch tweak");
+    assert!(input_bits<=f64::from(32+8 as u32), "Parameter mismatch: not enough field elements to encode the epoch tweak");
 
     
     let epoch_uint =  BigUint::from(epoch)<<8+crate::TWEAK_SEPARATOR_FOR_MESSAGE_HASH;

--- a/src/symmetric/message_hash/poseidon.rs
+++ b/src/symmetric/message_hash/poseidon.rs
@@ -18,8 +18,14 @@ use super::MessageHash;
 type F = FpBabyBear;
 
 /// Function to encode a message as a vector of field elements
-/// TODO: check that the output is big enough to hold the input
 fn encode_message<const MSG_LEN_FE: usize>(message: &[u8; MESSAGE_LENGTH]) -> [F;MSG_LEN_FE] {
+        //checking if we fit
+        let output_bits = f64::log2(
+            BigUint::from(FqConfig::MODULUS)
+            .to_string()
+            .parse()
+            .unwrap())*f64::from(MSG_LEN_FE as u32);
+        assert!(output_bits>=f64::from((8 as u32)*(MESSAGE_LENGTH as u32)), "Parameter mismatch: not enough field elements to encode the message");
      let msg_uint =  message.iter()
         .fold(BigUint::ZERO, |acc, &item|{
         acc*BigUint::from(256 as u32)+item
@@ -45,7 +51,7 @@ fn encode_epoch<const TWEAK_LEN_FE: usize>(epoch: u32) ->[F;TWEAK_LEN_FE] {
         .to_string()
         .parse()
         .unwrap())*f64::from(TWEAK_LEN_FE as u32);
-    assert!(input_bits<=f64::from(32+8 as u32), "Parameter mismatch: not enough field elements to encode the epoch tweak");
+    assert!(input_bits>=f64::from(32+8 as u32), "Parameter mismatch: not enough field elements to encode the epoch tweak");
 
     
     let epoch_uint =  BigUint::from(epoch)<<8+crate::TWEAK_SEPARATOR_FOR_MESSAGE_HASH;

--- a/src/symmetric/message_hash/sha.rs
+++ b/src/symmetric/message_hash/sha.rs
@@ -43,23 +43,6 @@ impl<
         randomness: &Self::Randomness,
         message: &[u8; MESSAGE_LENGTH],
     ) -> Vec<u8> {
-        assert!(
-            PARAMETER_LEN < 256 / 8,
-            "SHA256-Message Hash: Parameter Length must be less than 256 bit"
-        );
-        assert!(
-            RAND_LEN < 256 / 8,
-            "SHA256-Message Hash: Randomness Length must be less than 256 bit"
-        );
-        assert!(
-            RAND_LEN > 0,
-            "SHA256-Message Hash: Randomness Length must be non-zero"
-        );
-        assert!(
-            NUM_CHUNKS * CHUNK_SIZE < 256,
-            "SHA256-Message Hash: Hash Length (= NUM_CHUNKS * CHUNK_SIZE) must be less than 256 bit"
-        );
-
         let mut hasher = Sha256::new();
 
         // now add the parameter
@@ -83,6 +66,25 @@ impl<
         let chunks: Vec<u8> =
             bytes_to_chunks(&hash[0..NUM_CHUNKS * CHUNK_SIZE / 8], Self::CHUNK_SIZE);
         chunks
+    }
+
+    fn consistency_check() {
+        assert!(
+            PARAMETER_LEN < 256 / 8,
+            "SHA256-Message Hash: Parameter Length must be less than 256 bit"
+        );
+        assert!(
+            RAND_LEN < 256 / 8,
+            "SHA256-Message Hash: Randomness Length must be less than 256 bit"
+        );
+        assert!(
+            RAND_LEN > 0,
+            "SHA256-Message Hash: Randomness Length must be non-zero"
+        );
+        assert!(
+            NUM_CHUNKS * CHUNK_SIZE < 256,
+            "SHA256-Message Hash: Hash Length (= NUM_CHUNKS * CHUNK_SIZE) must be less than 256 bit"
+        );
     }
 }
 
@@ -111,6 +113,7 @@ mod tests {
         let epoch = 13;
         let randomness = Sha256MessageHash128x3::rand(&mut rng);
 
+        Sha256MessageHash128x3::consistency_check();
         Sha256MessageHash128x3::apply(&parameter, epoch, &randomness, &message);
     }
 
@@ -127,6 +130,7 @@ mod tests {
         let epoch = 13;
         let randomness = Sha256MessageHash192x3::rand(&mut rng);
 
+        Sha256MessageHash192x3::consistency_check();
         Sha256MessageHash192x3::apply(&parameter, epoch, &randomness, &message);
     }
 }

--- a/src/symmetric/tweak_hash.rs
+++ b/src/symmetric/tweak_hash.rs
@@ -67,8 +67,8 @@ pub(crate) fn chain<TH: TweakableHash>(
     current
 }
 
-pub mod sha;
 pub mod poseidon;
+pub mod sha;
 
 #[cfg(test)]
 mod tests {

--- a/src/symmetric/tweak_hash.rs
+++ b/src/symmetric/tweak_hash.rs
@@ -68,6 +68,7 @@ pub(crate) fn chain<TH: TweakableHash>(
 }
 
 pub mod sha;
+pub mod poseidon;
 
 #[cfg(test)]
 mod tests {

--- a/src/symmetric/tweak_hash.rs
+++ b/src/symmetric/tweak_hash.rs
@@ -29,7 +29,7 @@ pub trait TweakableHash {
 
     /// Returns a tweak to be used in chains.
     /// Note: this is assumed to be distinct from the outputs of tree_tweak
-    fn chain_tweak(epoch: u32, chain_index: u32, pos_in_chain: u32) -> Self::Tweak;
+    fn chain_tweak(epoch: u32, chain_index: u16, pos_in_chain: u16) -> Self::Tweak;
 
     /// Applies the tweakable hash to parameter, tweak, and message.
     fn apply(
@@ -49,8 +49,8 @@ pub trait TweakableHash {
 pub(crate) fn chain<TH: TweakableHash>(
     parameter: &TH::Parameter,
     epoch: u32,
-    chain_index: u32,
-    start_pos_in_chain: u32,
+    chain_index: u16,
+    start_pos_in_chain: u16,
     steps: usize,
     start: &TH::Domain,
 ) -> TH::Domain {
@@ -59,7 +59,7 @@ pub(crate) fn chain<TH: TweakableHash>(
 
     // otherwise, walk the right amount of steps
     for j in 0..steps {
-        let tweak = TH::chain_tweak(epoch, chain_index, start_pos_in_chain + (j as u32) + 1);
+        let tweak = TH::chain_tweak(epoch, chain_index, start_pos_in_chain + (j as u16) + 1);
         current = TH::apply(parameter, &tweak, &[current]);
     }
 
@@ -105,7 +105,7 @@ mod tests {
                 &parameter,
                 epoch,
                 chain_index,
-                steps_a as u32,
+                steps_a as u16,
                 steps_b,
                 &intermediate,
             );

--- a/src/symmetric/tweak_hash/poseidon.rs
+++ b/src/symmetric/tweak_hash/poseidon.rs
@@ -1,0 +1,237 @@
+use zkhash::ark_ff::One;
+use zkhash::ark_ff::Zero;
+use zkhash::ark_ff::UniformRand;
+use zkhash::poseidon2::poseidon2_instance_babybear::POSEIDON2_BABYBEAR_24_PARAMS;
+use zkhash::{fields::babybear::FpBabyBear, poseidon2::poseidon2::Poseidon2};
+
+use super::TweakableHash;
+
+// TODO: Check if we want to use this field or a different one
+type F = FpBabyBear;
+
+/// Enum to implement tweaks.
+pub enum PoseidonTweak<
+    const LOG_LIFETIME: usize,
+    const CEIL_LOG_NUM_CHAINS: usize,
+    const CHUNK_SIZE: usize,
+> {
+    TreeTweak {
+        level: u8,
+        pos_in_level: u32,
+    },
+    ChainTweak {
+        epoch: u32,
+        chain_index: u32,
+        pos_in_chain: u32,
+    },
+    _Marker(std::marker::PhantomData<F>),
+}
+
+impl<const LOG_LIFETIME: usize, const CEIL_LOG_NUM_CHAINS: usize, const CHUNK_SIZE: usize>
+    PoseidonTweak<LOG_LIFETIME, CEIL_LOG_NUM_CHAINS, CHUNK_SIZE>
+{
+    const TWEAK_LEN: usize = 6;
+
+    fn to_field_elements(&self) -> Vec<F> {
+        // TODO: implement tweaks properly
+        // we need to convert from integers to field elements,
+        // Note: taking into account the constants
+        // LOG_LIFETIME, CEIL_LOG_NUM_CHAINS, CHUNK_SIZE,
+        // we know that the tweak can be represented using at most
+        // LOG_LIFETIME + CEIL_LOG_NUM_CHAINS + CHUNK_SIZE many
+        // bits.
+        vec![F::zero(); Self::TWEAK_LEN]
+    }
+}
+
+/// Function to first pad input to appropriate length and
+/// then apply the Poseidon permutation.
+fn poseidon_padded_permute(instance: &Poseidon2<F>, input: &[F]) -> Vec<F> {
+    assert!(
+        input.len() <= instance.get_t(),
+        "Poseidon Compression: Input length too large for Poseidon parameters."
+    );
+
+    // pad input with zeroes to have exactly length instance.get_t()
+    let mut padded_input = input.to_vec();
+    padded_input.resize_with(instance.get_t(), F::zero);
+
+    // apply permutation and return
+    instance.permutation(&padded_input)
+}
+
+/// Poseidon Compression Function, using the Poseidon Permutation.
+/// It works as PoseidonCompress(x) = Truncate(PoseidonPermute(x) + x)
+fn poseidon_compress<const OUT_LEN: usize>(instance: &Poseidon2<F>, input: &[F]) -> [F; OUT_LEN] {
+    assert!(
+        input.len() >= OUT_LEN,
+        "Poseidon Compression: Input length must be at least output length."
+    );
+
+    // first permute input
+    let permuted_input = poseidon_padded_permute(instance, input);
+    // now, add them, but only for the positions
+    // we actually output.
+    let mut output = [F::one(); OUT_LEN];
+    for i in 0..OUT_LEN {
+        output[i] = permuted_input[i] + input[i];
+    }
+    output
+}
+
+/// A tweakable hash function implemented using Poseidon2
+///
+/// Note: HASH_LEN and PARAMETER_LEN must be given in
+/// the unit "number of field elements".
+pub struct PoseidonTweakHash<
+    const LOG_LIFETIME: usize,
+    const CEIL_LOG_NUM_CHAINS: usize,
+    const CHUNK_SIZE: usize,
+    const PARAMETER_LEN: usize,
+    const HASH_LEN: usize,
+>;
+
+impl<
+        const LOG_LIFETIME: usize,
+        const CEIL_LOG_NUM_CHAINS: usize,
+        const CHUNK_SIZE: usize,
+        const PARAMETER_LEN: usize,
+        const HASH_LEN: usize,
+    > TweakableHash
+    for PoseidonTweakHash<LOG_LIFETIME, CEIL_LOG_NUM_CHAINS, CHUNK_SIZE, PARAMETER_LEN, HASH_LEN>
+{
+    type Parameter = [F; PARAMETER_LEN];
+
+    type Tweak = PoseidonTweak<LOG_LIFETIME, CEIL_LOG_NUM_CHAINS, CHUNK_SIZE>;
+
+    type Domain = [F; HASH_LEN];
+
+    fn rand_parameter<R: rand::Rng>(rng: &mut R) -> Self::Parameter {
+        let mut par = [F::one(); PARAMETER_LEN];
+        for i in 0..PARAMETER_LEN {
+            par[i] = F::rand(rng);
+        }
+        par
+    }
+
+    fn rand_domain<R: rand::Rng>(rng: &mut R) -> Self::Domain {
+        let mut dom = [F::one(); HASH_LEN];
+        for i in 0..HASH_LEN {
+            dom[i] = F::rand(rng);
+        }
+        dom
+    }
+
+    fn tree_tweak(level: u8, pos_in_level: u32) -> Self::Tweak {
+        PoseidonTweak::TreeTweak {
+            level,
+            pos_in_level,
+        }
+    }
+
+    fn chain_tweak(epoch: u32, chain_index: u32, pos_in_chain: u32) -> Self::Tweak {
+        PoseidonTweak::ChainTweak {
+            epoch,
+            chain_index,
+            pos_in_chain,
+        }
+    }
+
+    fn apply(
+        parameter: &Self::Parameter,
+        tweak: &Self::Tweak,
+        message: &[Self::Domain],
+    ) -> Self::Domain {
+        assert!(
+            PARAMETER_LEN + Self::Tweak::TWEAK_LEN + 2 * HASH_LEN <= 24,
+            "Poseidon Tweak Hash: Input lengths too large for Poseidon instance"
+        );
+
+        // we are in one of three cases:
+        // (1) hashing within chains. We use compression mode.
+        // (2) hashing two siblings in the tree. We use compression mode.
+        // (3) hashing a long vector of chain ends. We use sponge mode.
+
+        let l = message.len();
+        let instance = Poseidon2::new(&POSEIDON2_BABYBEAR_24_PARAMS);
+        if l == 1 {
+            // we compress parameter, tweak, message
+            let message_unpacked = message[0];
+            let tweak_fe = tweak.to_field_elements();
+            let combined_input: Vec<F> = parameter
+                .iter()
+                .chain(tweak_fe.iter())
+                .chain(message_unpacked.iter())
+                .cloned()
+                .collect();
+            return poseidon_compress::<HASH_LEN>(&instance, &combined_input);
+        }
+        if l == 2 {
+            // we compress parameter, tweak, message (now containing two parts)
+            let message_unpacked_left = message[0];
+            let message_unpacked_right = message[1];
+            let tweak_fe = tweak.to_field_elements();
+            let combined_input: Vec<F> = parameter
+                .iter()
+                .chain(tweak_fe.iter())
+                .chain(message_unpacked_left.iter())
+                .chain(message_unpacked_right.iter())
+                .cloned()
+                .collect();
+            return poseidon_compress::<HASH_LEN>(&instance, &combined_input);
+        }
+        if l > 2 {
+            // TODO: implement Sponge mode
+            return [F::one(); HASH_LEN];
+        }
+        // will never be reached
+        [F::one(); HASH_LEN]
+    }
+}
+
+// Example instantiations
+pub type PoseidonTweak44 = PoseidonTweakHash<20, 8, 2, 4, 4>;
+pub type PoseidonTweak37 = PoseidonTweakHash<20, 8, 2, 3, 7>;
+
+#[cfg(test)]
+mod tests {
+    use rand::thread_rng;
+
+    use super::*;
+
+    #[test]
+    fn test_apply_44() {
+        let mut rng = thread_rng();
+
+        // test that nothing is panicking
+        let parameter = PoseidonTweak44::rand_parameter(&mut rng);
+        let message_one = PoseidonTweak44::rand_domain(&mut rng);
+        let message_two = PoseidonTweak44::rand_domain(&mut rng);
+        let tweak_tree = PoseidonTweak44::tree_tweak(0, 3);
+        PoseidonTweak44::apply(&parameter, &tweak_tree, &[message_one, message_two]);
+
+        // test that nothing is panicking
+        let parameter = PoseidonTweak44::rand_parameter(&mut rng);
+        let message_one = PoseidonTweak44::rand_domain(&mut rng);
+        let tweak_chain = PoseidonTweak44::chain_tweak(2, 3, 4);
+        PoseidonTweak44::apply(&parameter, &tweak_chain, &[message_one]);
+    }
+
+    #[test]
+    fn test_apply_37() {
+        let mut rng = thread_rng();
+
+        // test that nothing is panicking
+        let parameter = PoseidonTweak37::rand_parameter(&mut rng);
+        let message_one = PoseidonTweak37::rand_domain(&mut rng);
+        let message_two = PoseidonTweak37::rand_domain(&mut rng);
+        let tweak_tree = PoseidonTweak37::tree_tweak(0, 3);
+        PoseidonTweak37::apply(&parameter, &tweak_tree, &[message_one, message_two]);
+
+        // test that nothing is panicking
+        let parameter = PoseidonTweak37::rand_parameter(&mut rng);
+        let message_one = PoseidonTweak37::rand_domain(&mut rng);
+        let tweak_chain = PoseidonTweak37::chain_tweak(2, 3, 4);
+        PoseidonTweak37::apply(&parameter, &tweak_chain, &[message_one]);
+    }
+}

--- a/src/symmetric/tweak_hash/poseidon.rs
+++ b/src/symmetric/tweak_hash/poseidon.rs
@@ -1,6 +1,6 @@
 use zkhash::ark_ff::One;
-use zkhash::ark_ff::Zero;
 use zkhash::ark_ff::UniformRand;
+use zkhash::ark_ff::Zero;
 use zkhash::poseidon2::poseidon2_instance_babybear::POSEIDON2_BABYBEAR_24_PARAMS;
 use zkhash::{fields::babybear::FpBabyBear, poseidon2::poseidon2::Poseidon2};
 
@@ -62,7 +62,10 @@ fn poseidon_padded_permute(instance: &Poseidon2<F>, input: &[F]) -> Vec<F> {
 
 /// Poseidon Compression Function, using the Poseidon Permutation.
 /// It works as PoseidonCompress(x) = Truncate(PoseidonPermute(x) + x)
-fn poseidon_compress<const OUT_LEN: usize>(instance: &Poseidon2<F>, input: &[F]) -> [F; OUT_LEN] {
+pub fn poseidon_compress<const OUT_LEN: usize>(
+    instance: &Poseidon2<F>,
+    input: &[F],
+) -> [F; OUT_LEN] {
     assert!(
         input.len() >= OUT_LEN,
         "Poseidon Compression: Input length must be at least output length."

--- a/src/symmetric/tweak_hash/poseidon.rs
+++ b/src/symmetric/tweak_hash/poseidon.rs
@@ -1,8 +1,13 @@
+use std::default;
+
 use zkhash::ark_ff::One;
 use zkhash::ark_ff::UniformRand;
 use zkhash::ark_ff::Zero;
+use zkhash::ark_ff::MontConfig;
 use zkhash::poseidon2::poseidon2_instance_babybear::POSEIDON2_BABYBEAR_24_PARAMS;
-use zkhash::{fields::babybear::FpBabyBear, poseidon2::poseidon2::Poseidon2};
+use zkhash::{fields::babybear::{FpBabyBear,FqConfig}, poseidon2::poseidon2::Poseidon2};
+
+use num_bigint::BigUint;
 
 use super::TweakableHash;
 
@@ -21,8 +26,8 @@ pub enum PoseidonTweak<
     },
     ChainTweak {
         epoch: u32,
-        chain_index: u32,
-        pos_in_chain: u32,
+        chain_index: u16,
+        pos_in_chain: u16,
     },
     _Marker(std::marker::PhantomData<F>),
 }
@@ -30,9 +35,9 @@ pub enum PoseidonTweak<
 impl<const LOG_LIFETIME: usize, const CEIL_LOG_NUM_CHAINS: usize, const CHUNK_SIZE: usize>
     PoseidonTweak<LOG_LIFETIME, CEIL_LOG_NUM_CHAINS, CHUNK_SIZE>
 {
-    const TWEAK_LEN: usize = 6;
+    //const TWEAK_LEN: usize = 6;
 
-    fn to_field_elements(&self) -> Vec<F> {
+    fn to_field_elements<const TWEAK_LEN: usize>(&self) -> Vec<F> {
         // TODO: implement tweaks properly
         // we need to convert from integers to field elements,
         // Note: taking into account the constants
@@ -40,7 +45,39 @@ impl<const LOG_LIFETIME: usize, const CEIL_LOG_NUM_CHAINS: usize, const CHUNK_SI
         // we know that the tweak can be represented using at most
         // LOG_LIFETIME + CEIL_LOG_NUM_CHAINS + CHUNK_SIZE many
         // bits.
-        vec![F::zero(); Self::TWEAK_LEN]
+
+        let tweak_bigint = match self {
+            PoseidonTweak::TreeTweak {
+                level,
+                pos_in_level,
+            } => {
+                (BigUint::from(*level)<<40)
+                + (BigUint::from(*pos_in_level)<<8)
+                +crate::TWEAK_SEPARATOR_FOR_TREE_HASH
+            }
+            PoseidonTweak::ChainTweak {
+                epoch,
+                chain_index,
+                pos_in_chain,
+            } => {
+                (BigUint::from(*epoch)<<40)
+                + (BigUint::from(*chain_index)<<24) 
+                + (BigUint::from(*pos_in_chain)<<8)
+                +crate::TWEAK_SEPARATOR_FOR_CHAIN_HASH
+            }
+            default=>{
+                BigUint::from(0 as u32)
+            }
+        };
+        let mut tweak_fe: [F;TWEAK_LEN] = [F::from(0);TWEAK_LEN];
+        tweak_fe.iter_mut()
+            .fold(tweak_bigint, |acc,  item|{  
+            let tmp = acc.clone()% BigUint::from(FqConfig::MODULUS);
+            *item = F::from(tmp.clone());
+            (acc-tmp)/(BigUint::from(FqConfig::MODULUS)) 
+        }); //interpreting the number base-p
+        tweak_fe.to_vec()
+        
     }
 }
 
@@ -75,7 +112,7 @@ pub fn poseidon_compress<const OUT_LEN: usize>(
     let permuted_input = poseidon_padded_permute(instance, input);
     // now, add them, but only for the positions
     // we actually output.
-    let mut output = [F::one(); OUT_LEN];
+    let mut output = [F::zero(); OUT_LEN];
     for i in 0..OUT_LEN {
         output[i] = permuted_input[i] + input[i];
     }
@@ -92,6 +129,7 @@ pub struct PoseidonTweakHash<
     const CHUNK_SIZE: usize,
     const PARAMETER_LEN: usize,
     const HASH_LEN: usize,
+    const TWEAK_LEN: usize,
 >;
 
 impl<
@@ -100,8 +138,9 @@ impl<
         const CHUNK_SIZE: usize,
         const PARAMETER_LEN: usize,
         const HASH_LEN: usize,
+        const TWEAK_LEN: usize,
     > TweakableHash
-    for PoseidonTweakHash<LOG_LIFETIME, CEIL_LOG_NUM_CHAINS, CHUNK_SIZE, PARAMETER_LEN, HASH_LEN>
+    for PoseidonTweakHash<LOG_LIFETIME, CEIL_LOG_NUM_CHAINS, CHUNK_SIZE, PARAMETER_LEN, HASH_LEN, TWEAK_LEN>
 {
     type Parameter = [F; PARAMETER_LEN];
 
@@ -132,7 +171,7 @@ impl<
         }
     }
 
-    fn chain_tweak(epoch: u32, chain_index: u32, pos_in_chain: u32) -> Self::Tweak {
+    fn chain_tweak(epoch: u32, chain_index: u16, pos_in_chain: u16) -> Self::Tweak {
         PoseidonTweak::ChainTweak {
             epoch,
             chain_index,
@@ -146,7 +185,7 @@ impl<
         message: &[Self::Domain],
     ) -> Self::Domain {
         assert!(
-            PARAMETER_LEN + Self::Tweak::TWEAK_LEN + 2 * HASH_LEN <= 24,
+            PARAMETER_LEN + TWEAK_LEN + 2 * HASH_LEN <= 24,
             "Poseidon Tweak Hash: Input lengths too large for Poseidon instance"
         );
 
@@ -160,7 +199,7 @@ impl<
         if l == 1 {
             // we compress parameter, tweak, message
             let message_unpacked = message[0];
-            let tweak_fe = tweak.to_field_elements();
+            let tweak_fe = PoseidonTweak::to_field_elements::<TWEAK_LEN>(tweak);
             let combined_input: Vec<F> = parameter
                 .iter()
                 .chain(tweak_fe.iter())
@@ -173,7 +212,7 @@ impl<
             // we compress parameter, tweak, message (now containing two parts)
             let message_unpacked_left = message[0];
             let message_unpacked_right = message[1];
-            let tweak_fe = tweak.to_field_elements();
+            let tweak_fe = PoseidonTweak::to_field_elements::<TWEAK_LEN>(tweak);
             let combined_input: Vec<F> = parameter
                 .iter()
                 .chain(tweak_fe.iter())
@@ -193,8 +232,8 @@ impl<
 }
 
 // Example instantiations
-pub type PoseidonTweak44 = PoseidonTweakHash<20, 8, 2, 4, 4>;
-pub type PoseidonTweak37 = PoseidonTweakHash<20, 8, 2, 3, 7>;
+pub type PoseidonTweak44 = PoseidonTweakHash<20, 8, 2, 4, 4,3>;
+pub type PoseidonTweak37 = PoseidonTweakHash<20, 8, 2, 3, 7,3>;
 
 #[cfg(test)]
 mod tests {

--- a/src/symmetric/tweak_hash/sha.rs
+++ b/src/symmetric/tweak_hash/sha.rs
@@ -10,8 +10,8 @@ pub enum Sha256Tweak {
     },
     ChainTweak {
         epoch: u32,
-        chain_index: u32,
-        pos_in_chain: u32,
+        chain_index: u16,
+        pos_in_chain: u16,
     },
 }
 
@@ -86,7 +86,7 @@ impl<const PARAMETER_LEN: usize, const HASH_LEN: usize> TweakableHash
         }
     }
 
-    fn chain_tweak(epoch: u32, chain_index: u32, pos_in_chain: u32) -> Self::Tweak {
+    fn chain_tweak(epoch: u32, chain_index: u16, pos_in_chain: u16) -> Self::Tweak {
         Sha256Tweak::ChainTweak {
             epoch,
             chain_index,


### PR DESCRIPTION
- Added `num-bigint` dependency
- Chain lengths and indices are now u16 to have a smaller tweak
- MESSAGE_LENGTH changed to 32 for smaller hash
- Tweak separator values added
- Poseidon Message Hash now has TWEAK_LEN_FE and MSG_LEN_FE parameters
- Message encoded for hashing in Poseidon message hash
- Epoch/tweak encoded for hashing in Poseidon message hash
- Poseidon message hash decoded to chunks
- Poseidon Tweakable Hash now has TWEAK_LEN, CAPACITY, and NUM_CHUNKS parameter
- Tweak to FE functions  constructed for Poseidon
- Domain separator function for Poseidon SAFE Sponge
- Tweakable hashing for leafs implemented via Poseidon SAFE Sponge
- Small test added for leaf hashing