### PR TITLE
Adding Poseidon hash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 rand = "0.8.5" 
-sha2 = "0.10.8"
+sha3 = "0.10.8"
 zkhash = { git = "https://github.com/HorizenLabs/poseidon2", branch = "main", package = "zkhash" }
 num-bigint = "0.4.6" 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-rand = "0.8.5"
-sha3 = "0.10.8"
+rand = "0.8.5" 
+sha2 = "0.10.8"
+zkhash = { git = "https://github.com/HorizenLabs/poseidon2", branch = "main", package = "zkhash" }
+num-bigint = "0.4.6" 
 
 [dev-dependencies]
 criterion = "0.4"

--- a/src/inc_encoding.rs
+++ b/src/inc_encoding.rs
@@ -41,7 +41,7 @@ pub trait IncomparableEncoding {
         message: &[u8; MESSAGE_LENGTH],
         randomness: &Self::Randomness,
         epoch: u32,
-    ) -> Result<Vec<u32>, EncodingError>;
+    ) -> Result<Vec<u16>, EncodingError>;
 }
 
 pub mod basic_winternitz;

--- a/src/inc_encoding/basic_winternitz.rs
+++ b/src/inc_encoding/basic_winternitz.rs
@@ -53,7 +53,7 @@ impl<MH: MessageHash, const NUM_CHUNKS_CHECKSUM: usize> IncomparableEncoding
         message: &[u8; MESSAGE_LENGTH],
         randomness: &Self::Randomness,
         epoch: u32,
-    ) -> Result<Vec<u32>, super::EncodingError> {
+    ) -> Result<Vec<u16>, super::EncodingError> {
         // apply the message hash to get chunks
         let chunks_message = MH::apply(parameter, epoch, randomness, message);
 
@@ -74,7 +74,7 @@ impl<MH: MessageHash, const NUM_CHUNKS_CHECKSUM: usize> IncomparableEncoding
         let mut chunks = Vec::with_capacity(chunks_message.len() + NUM_CHUNKS_CHECKSUM);
         chunks.extend_from_slice(&chunks_message);
         chunks.extend_from_slice(&chunks_checksum[..NUM_CHUNKS_CHECKSUM]);
-        let chunks_u32: Vec<u32> = chunks.iter().map(|&x| x as u32).collect();
-        Ok(chunks_u32)
+        let chunks_u16: Vec<u16> = chunks.iter().map(|&x| x as u16).collect();
+        Ok(chunks_u16)
     }
 }

--- a/src/inc_encoding/target_sum.rs
+++ b/src/inc_encoding/target_sum.rs
@@ -1,4 +1,4 @@
-use crate::symmetric::message_hash::MessageHash;
+use crate::{symmetric::message_hash::MessageHash, MESSAGE_LENGTH};
 
 use super::IncomparableEncoding;
 
@@ -45,19 +45,21 @@ impl<MH: MessageHash, const TARGET_SUM: usize> IncomparableEncoding
 
     fn encode(
         parameter: &Self::Parameter,
-        message: &[u8; 64],
+        message: &[u8; MESSAGE_LENGTH],
         randomness: &Self::Randomness,
         epoch: u32,
-    ) -> Result<Vec<u32>, super::EncodingError> {
+    ) -> Result<Vec<u16>, super::EncodingError> {
         // apply the message hash first to get chunks
         let chunks = MH::apply(parameter, epoch, randomness, message);
+        let chunks_u16: Vec<u16> = chunks.iter().map(|&x| x as u16).collect();
         let chunks_u32: Vec<u32> = chunks.iter().map(|&x| x as u32).collect();
+
         let sum: u32 = chunks_u32.iter().sum();
         // only output the chunks sum to the target sum
         return if sum as usize != Self::TARGET_SUM {
             Err(())
         } else {
-            Ok(chunks_u32)
+            Ok(chunks_u16)
         };
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,9 @@
 /// Message length in bytes, for messages
 /// that we want to sign.
-pub const MESSAGE_LENGTH: usize = 64;
+pub const MESSAGE_LENGTH: usize = 32;
+pub const TWEAK_SEPARATOR_FOR_MESSAGE_HASH: u8 = 2;
+pub const TWEAK_SEPARATOR_FOR_TREE_HASH: u8 = 1;
+pub const TWEAK_SEPARATOR_FOR_CHAIN_HASH: u8 = 0;
 
 pub mod inc_encoding;
 pub mod signature;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub const MESSAGE_LENGTH: usize = 32;
 pub const TWEAK_SEPARATOR_FOR_MESSAGE_HASH: u8 = 2;
 pub const TWEAK_SEPARATOR_FOR_TREE_HASH: u8 = 1;
 pub const TWEAK_SEPARATOR_FOR_CHAIN_HASH: u8 = 0;
+const DOMAIN_PARAMETERS_LENGTH: usize = 4;
 
 pub mod inc_encoding;
 pub mod signature;

--- a/src/signature/generalized_xmss.rs
+++ b/src/signature/generalized_xmss.rs
@@ -110,7 +110,7 @@ where
                 let end = chain::<TH>(
                     &parameter,
                     epoch as u32,
-                    chain_index as u32,
+                    chain_index as u16,
                     0,
                     chain_length - 1,
                     &start,
@@ -147,7 +147,7 @@ where
         rng: &mut R,
         sk: &Self::SecretKey,
         epoch: u32,
-        message: &[u8; 64],
+        message: &[u8; MESSAGE_LENGTH],
     ) -> Result<Self::Signature, SigningError> {
         // check first that we have the correct message length
         if message.len() != MESSAGE_LENGTH {
@@ -205,7 +205,7 @@ where
             let hash_in_chain = chain::<TH>(
                 &sk.parameter,
                 epoch,
-                chain_index as u32,
+                chain_index as u16,
                 0,
                 steps as usize,
                 &start,
@@ -254,7 +254,7 @@ where
             let end = chain::<TH>(
                 &pk.parameter,
                 epoch,
-                chain_index as u32,
+                chain_index as u16,
                 start_pos_in_chain,
                 steps as usize,
                 start,

--- a/src/symmetric/message_hash.rs
+++ b/src/symmetric/message_hash.rs
@@ -30,8 +30,13 @@ pub trait MessageHash {
         randomness: &Self::Randomness,
         message: &[u8; MESSAGE_LENGTH],
     ) -> Vec<u8>;
+
+    /// Check that the parameters are sound and internally consistent
+    /// Panics if smth is wrong
+    fn consistency_check();
 }
 
+pub mod poseidon;
 pub mod sha;
 
 /// Isolates a chunk of bits from a byte based on the specified chunk index and chunk size.

--- a/src/symmetric/message_hash/poseidon.rs
+++ b/src/symmetric/message_hash/poseidon.rs
@@ -1,0 +1,219 @@
+use num_bigint::BigUint;
+use zkhash::ark_ff::MontConfig;
+use zkhash::ark_ff::PrimeField;
+use zkhash::ark_ff::UniformRand;
+use zkhash::ark_ff::{One, Zero};
+use zkhash::fields::babybear::FpBabyBear;
+use zkhash::fields::babybear::FqConfig;
+use zkhash::poseidon2::poseidon2::Poseidon2;
+use zkhash::poseidon2::poseidon2_instance_babybear::POSEIDON2_BABYBEAR_24_PARAMS;
+
+use super::MessageHash;
+use crate::symmetric::tweak_hash::poseidon::poseidon_compress;
+use crate::MESSAGE_LENGTH;
+
+type F = FpBabyBear;
+
+/// Function to encode a message as a vector of field elements
+fn encode_message<const MSG_LEN_FE: usize>(message: &[u8; MESSAGE_LENGTH]) -> [F; MSG_LEN_FE] {
+    let msg_uint = BigUint::from_bytes_le(message); //collect the vector into a number
+
+    let mut message_fe: [F; MSG_LEN_FE] = [F::zero(); MSG_LEN_FE];
+    message_fe.iter_mut().fold(msg_uint, |acc, item| {
+        let tmp = acc.clone() % BigUint::from(FqConfig::MODULUS);
+        *item = F::from(tmp.clone());
+        (acc - tmp) / (BigUint::from(FqConfig::MODULUS))
+    }); //interpreting the number base-p
+    message_fe
+}
+
+/// Function to encode an epoch (= tweak in the message hash)
+/// as a vector of field elements.
+///
+fn encode_epoch<const TWEAK_LEN_FE: usize>(epoch: u32) -> [F; TWEAK_LEN_FE] {
+    let epoch_uint: BigUint = (BigUint::from(epoch) << 8) + crate::TWEAK_SEPARATOR_FOR_MESSAGE_HASH;
+    //collect the vector into a number
+
+    let mut tweak_fe: [F; TWEAK_LEN_FE] = [F::zero(); TWEAK_LEN_FE];
+    tweak_fe.iter_mut().fold(epoch_uint, |acc, item| {
+        let tmp = acc.clone() % BigUint::from(FqConfig::MODULUS);
+        *item = F::from(tmp.clone());
+        (acc - tmp) / (BigUint::from(FqConfig::MODULUS))
+    }); //interpreting the number base-p
+    tweak_fe
+}
+
+/// Function to decode a vector of field elements into
+/// a vector of NUM_CHUNKS many chunks. One chunk is
+/// between 0 and 2^CHUNK_SIZE - 1 (inclusive).
+fn decode_to_chunks<const NUM_CHUNKS: usize, const CHUNK_SIZE: usize, const HASH_LEN_FE: usize>(
+    field_elements: &[F; HASH_LEN_FE],
+) -> Vec<u8> {
+    let hash_uint = field_elements.iter().fold(BigUint::ZERO, |acc, &item| {
+        acc * BigUint::from(FqConfig::MODULUS) + BigUint::from(item.into_bigint())
+    }); //collect the vector into a number
+
+    let chunk_len = (1 << CHUNK_SIZE) as u8;
+
+    let mut hash_chunked: [u8; NUM_CHUNKS] = [0 as u8; NUM_CHUNKS];
+    hash_chunked.iter_mut().fold(hash_uint, |acc, item| {
+        let tmp = acc.clone() % chunk_len;
+        *item = tmp.to_bytes_le()[0] % chunk_len;
+        (acc - tmp) / chunk_len
+    }); //interpreting the number base-p
+    Vec::from(hash_chunked)
+}
+
+/// A message hash implemented using Poseidon2
+///
+/// Note: PARAMETER_LEN, RAND_LEN, TWEAK_LEN_FE, MSG_LEN_FE, and HASH_LEN_FE
+/// must be given in the unit "number of field elements".
+///
+/// HASH_LEN_FE specifies how many field elements the
+/// hash output needs to be before it is decoded to chunks.
+///
+/// CHUNK_SIZE has to be 1,2,4, or 8.
+pub struct PoseidonMessageHash<
+    const PARAMETER_LEN: usize,
+    const RAND_LEN: usize,
+    const HASH_LEN_FE: usize,
+    const NUM_CHUNKS: usize,
+    const CHUNK_SIZE: usize,
+    const TWEAK_LEN_FE: usize,
+    const MSG_LEN_FE: usize,
+>;
+
+impl<
+        const PARAMETER_LEN: usize,
+        const RAND_LEN: usize,
+        const HASH_LEN_FE: usize,
+        const NUM_CHUNKS: usize,
+        const CHUNK_SIZE: usize,
+        const TWEAK_LEN_FE: usize,
+        const MSG_LEN_FE: usize,
+    > MessageHash
+    for PoseidonMessageHash<
+        PARAMETER_LEN,
+        RAND_LEN,
+        HASH_LEN_FE,
+        NUM_CHUNKS,
+        CHUNK_SIZE,
+        TWEAK_LEN_FE,
+        MSG_LEN_FE,
+    >
+{
+    type Parameter = [F; PARAMETER_LEN];
+
+    type Randomness = [F; RAND_LEN];
+
+    const NUM_CHUNKS: usize = NUM_CHUNKS;
+
+    const CHUNK_SIZE: usize = CHUNK_SIZE;
+
+    fn rand<R: rand::Rng>(rng: &mut R) -> Self::Randomness {
+        let mut rnd = [F::one(); RAND_LEN];
+        for i in 0..RAND_LEN {
+            rnd[i] = F::rand(rng);
+        }
+        rnd
+    }
+
+    fn apply(
+        parameter: &Self::Parameter,
+        epoch: u32,
+        randomness: &Self::Randomness,
+        message: &[u8; MESSAGE_LENGTH],
+    ) -> Vec<u8> {
+        // We need a Poseidon instance
+
+        //This block should be changed if we decide to support other Poseidon instances
+        //Currently we use state of width 24 and pad with 0s
+        assert!(PARAMETER_LEN + TWEAK_LEN_FE + RAND_LEN + MSG_LEN_FE <= 24);
+        let instance = Poseidon2::new(&POSEIDON2_BABYBEAR_24_PARAMS);
+
+        // first, encode the message and the epoch as field elements
+        let message_fe = encode_message::<MSG_LEN_FE>(message);
+        let epoch_fe = encode_epoch::<TWEAK_LEN_FE>(epoch);
+
+        // now, we hash parameters, epoch, message, randomness using PoseidonCompress
+        let combined_input: Vec<F> = parameter
+            .iter()
+            .chain(epoch_fe.iter())
+            .chain(message_fe.iter())
+            .chain(randomness.iter())
+            .cloned()
+            .collect();
+        let hash_fe = poseidon_compress::<HASH_LEN_FE>(&instance, &combined_input);
+
+        // decode field elements into chunks and return them
+        decode_to_chunks::<NUM_CHUNKS, CHUNK_SIZE, HASH_LEN_FE>(&hash_fe)
+    }
+
+    fn consistency_check() {
+        //message check
+        let msg_fe_bits = f64::log2(
+            BigUint::from(FqConfig::MODULUS)
+                .to_string()
+                .parse()
+                .unwrap(),
+        ) * f64::from(MSG_LEN_FE as u32);
+        assert!(
+            msg_fe_bits >= f64::from((8 as u32) * (MESSAGE_LENGTH as u32)),
+            "Poseidon Message hash. Parameter mismatch: not enough field elements to encode the message"
+        );
+
+        //tweak check
+        let tweak_fe_bits = f64::log2(
+            BigUint::from(FqConfig::MODULUS)
+                .to_string()
+                .parse()
+                .unwrap(),
+        ) * f64::from(TWEAK_LEN_FE as u32);
+        assert!(
+            tweak_fe_bits >= f64::from(32 + 8 as u32),
+            "Poseidon Message hash. Parameter mismatch: not enough field elements to encode the epoch tweak"
+        );
+
+        //Decoding check
+        let hash_bits = f64::log2(
+            BigUint::from(FqConfig::MODULUS)
+                .to_string()
+                .parse()
+                .unwrap(),
+        ) * f64::from(HASH_LEN_FE as u32);
+        assert!(
+            hash_bits <= f64::from((NUM_CHUNKS * CHUNK_SIZE) as u32),
+            "Poseidon Message hash. Parameter mismatch: not enough chunks to decode the hash"
+        );
+    }
+}
+
+// Example instantiations
+// TODO: check if this instantiation makes any sense
+pub type PoseidonMessageHash445 = PoseidonMessageHash<4, 4, 5, 128, 2, 2, 9>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::{thread_rng, Rng};
+    use zkhash::ark_ff::UniformRand;
+
+    #[test]
+    fn test_apply() {
+        let mut rng = thread_rng();
+
+        let mut parameter = [F::one(); 4];
+        for i in 0..4 {
+            parameter[i] = F::rand(&mut rng);
+        }
+
+        let mut message = [0u8; MESSAGE_LENGTH];
+        rng.fill(&mut message);
+
+        let epoch = 13;
+        let randomness = PoseidonMessageHash445::rand(&mut rng);
+
+        PoseidonMessageHash445::consistency_check();
+        PoseidonMessageHash445::apply(&parameter, epoch, &randomness, &message);
+    }
+}

--- a/src/symmetric/message_hash/sha.rs
+++ b/src/symmetric/message_hash/sha.rs
@@ -42,28 +42,9 @@ impl<
         epoch: u32,
         randomness: &Self::Randomness,
         message: &[u8; MESSAGE_LENGTH],
-    ) -> Vec<u8> {
-        assert!(
-            PARAMETER_LEN < 256 / 8,
-            "SHA Message Hash: Parameter Length must be less than 256 bit"
-        );
-        assert!(
-            RAND_LEN < 256 / 8,
-            "SHA Message Hash: Randomness Length must be less than 256 bit"
-        );
-        assert!(
-            RAND_LEN > 0,
-            "SHA Message Hash: Randomness Length must be non-zero"
-        );
-        assert!(
-            NUM_CHUNKS * CHUNK_SIZE < 256,
-            "SHA Message Hash: Hash Length (= NUM_CHUNKS * CHUNK_SIZE) must be less than 256 bit"
-        );
-
-        let mut hasher = Sha3_256::new();
-
-        // first add randomness
-        hasher.update(randomness);
+    ) -> Vec<u8> { 
+        let mut hasher = Sha256::new();
+ 
 
         // now add the parameter
         hasher.update(parameter);
@@ -83,6 +64,25 @@ impl<
         let chunks: Vec<u8> =
             bytes_to_chunks(&hash[0..NUM_CHUNKS * CHUNK_SIZE / 8], Self::CHUNK_SIZE);
         chunks
+    }
+
+    fn consistency_check() {
+        assert!(
+            PARAMETER_LEN < 256 / 8,
+            "SHA256-Message Hash: Parameter Length must be less than 256 bit"
+        );
+        assert!(
+            RAND_LEN < 256 / 8,
+            "SHA256-Message Hash: Randomness Length must be less than 256 bit"
+        );
+        assert!(
+            RAND_LEN > 0,
+            "SHA256-Message Hash: Randomness Length must be non-zero"
+        );
+        assert!(
+            NUM_CHUNKS * CHUNK_SIZE < 256,
+            "SHA256-Message Hash: Hash Length (= NUM_CHUNKS * CHUNK_SIZE) must be less than 256 bit"
+        );
     }
 }
 
@@ -110,8 +110,9 @@ mod tests {
 
         let epoch = 13;
         let randomness = ShaMessageHash128x3::rand(&mut rng);
-
-        ShaMessageHash128x3::apply(&parameter, epoch, &randomness, &message);
+ 
+        Sha256MessageHash128x3::consistency_check();
+        Sha256MessageHash128x3::apply(&parameter, epoch, &randomness, &message); 
     }
 
     #[test]
@@ -126,7 +127,8 @@ mod tests {
 
         let epoch = 13;
         let randomness = ShaMessageHash192x3::rand(&mut rng);
-
-        ShaMessageHash192x3::apply(&parameter, epoch, &randomness, &message);
+ 
+        Sha256MessageHash192x3::consistency_check();
+        Sha256MessageHash192x3::apply(&parameter, epoch, &randomness, &message); 
     }
 }

--- a/src/symmetric/message_hash/sha.rs
+++ b/src/symmetric/message_hash/sha.rs
@@ -43,7 +43,7 @@ impl<
         randomness: &Self::Randomness,
         message: &[u8; MESSAGE_LENGTH],
     ) -> Vec<u8> { 
-        let mut hasher = Sha256::new();
+        let mut hasher = Sha3_256::new();
  
 
         // now add the parameter
@@ -111,8 +111,8 @@ mod tests {
         let epoch = 13;
         let randomness = ShaMessageHash128x3::rand(&mut rng);
  
-        Sha256MessageHash128x3::consistency_check();
-        Sha256MessageHash128x3::apply(&parameter, epoch, &randomness, &message); 
+        ShaMessageHash128x3::consistency_check();
+        ShaMessageHash128x3::apply(&parameter, epoch, &randomness, &message); 
     }
 
     #[test]
@@ -128,7 +128,7 @@ mod tests {
         let epoch = 13;
         let randomness = ShaMessageHash192x3::rand(&mut rng);
  
-        Sha256MessageHash192x3::consistency_check();
-        Sha256MessageHash192x3::apply(&parameter, epoch, &randomness, &message); 
+        ShaMessageHash192x3::consistency_check();
+        ShaMessageHash192x3::apply(&parameter, epoch, &randomness, &message); 
     }
 }

--- a/src/symmetric/message_hash/sha.rs
+++ b/src/symmetric/message_hash/sha.rs
@@ -44,8 +44,10 @@ impl<
         message: &[u8; MESSAGE_LENGTH],
     ) -> Vec<u8> { 
         let mut hasher = Sha3_256::new();
- 
 
+        // first add randomness
+        hasher.update(randomness);
+        
         // now add the parameter
         hasher.update(parameter);
 

--- a/src/symmetric/message_hash/sha.rs
+++ b/src/symmetric/message_hash/sha.rs
@@ -42,12 +42,12 @@ impl<
         epoch: u32,
         randomness: &Self::Randomness,
         message: &[u8; MESSAGE_LENGTH],
-    ) -> Vec<u8> { 
+    ) -> Vec<u8> {
         let mut hasher = Sha3_256::new();
 
         // first add randomness
         hasher.update(randomness);
-        
+
         // now add the parameter
         hasher.update(parameter);
 
@@ -112,9 +112,9 @@ mod tests {
 
         let epoch = 13;
         let randomness = ShaMessageHash128x3::rand(&mut rng);
- 
+
         ShaMessageHash128x3::consistency_check();
-        ShaMessageHash128x3::apply(&parameter, epoch, &randomness, &message); 
+        ShaMessageHash128x3::apply(&parameter, epoch, &randomness, &message);
     }
 
     #[test]
@@ -129,8 +129,8 @@ mod tests {
 
         let epoch = 13;
         let randomness = ShaMessageHash192x3::rand(&mut rng);
- 
+
         ShaMessageHash192x3::consistency_check();
-        ShaMessageHash192x3::apply(&parameter, epoch, &randomness, &message); 
+        ShaMessageHash192x3::apply(&parameter, epoch, &randomness, &message);
     }
 }

--- a/src/symmetric/tweak_hash.rs
+++ b/src/symmetric/tweak_hash.rs
@@ -29,7 +29,7 @@ pub trait TweakableHash {
 
     /// Returns a tweak to be used in chains.
     /// Note: this is assumed to be distinct from the outputs of tree_tweak
-    fn chain_tweak(epoch: u32, chain_index: u32, pos_in_chain: u32) -> Self::Tweak;
+    fn chain_tweak(epoch: u32, chain_index: u16, pos_in_chain: u16) -> Self::Tweak;
 
     /// Applies the tweakable hash to parameter, tweak, and message.
     fn apply(
@@ -49,8 +49,8 @@ pub trait TweakableHash {
 pub(crate) fn chain<TH: TweakableHash>(
     parameter: &TH::Parameter,
     epoch: u32,
-    chain_index: u32,
-    start_pos_in_chain: u32,
+    chain_index: u16,
+    start_pos_in_chain: u16,
     steps: usize,
     start: &TH::Domain,
 ) -> TH::Domain {
@@ -59,7 +59,7 @@ pub(crate) fn chain<TH: TweakableHash>(
 
     // otherwise, walk the right amount of steps
     for j in 0..steps {
-        let tweak = TH::chain_tweak(epoch, chain_index, start_pos_in_chain + (j as u32) + 1);
+        let tweak = TH::chain_tweak(epoch, chain_index, start_pos_in_chain + (j as u16) + 1);
         current = TH::apply(parameter, &tweak, &[current]);
     }
 
@@ -67,6 +67,7 @@ pub(crate) fn chain<TH: TweakableHash>(
     current
 }
 
+pub mod poseidon;
 pub mod sha;
 
 #[cfg(test)]
@@ -104,7 +105,7 @@ mod tests {
                 &parameter,
                 epoch,
                 chain_index,
-                steps_a as u32,
+                steps_a as u16,
                 steps_b,
                 &intermediate,
             );

--- a/src/symmetric/tweak_hash.rs
+++ b/src/symmetric/tweak_hash.rs
@@ -37,6 +37,9 @@ pub trait TweakableHash {
         tweak: &Self::Tweak,
         message: &[Self::Domain],
     ) -> Self::Domain;
+
+    /// Checks that parameter lengths are consistent with the inner hash function
+    fn consistency_check() -> bool;
 }
 
 /// Function implementing hash chains, implemented over a tweakable hash function

--- a/src/symmetric/tweak_hash/poseidon.rs
+++ b/src/symmetric/tweak_hash/poseidon.rs
@@ -2,7 +2,7 @@ use zkhash::ark_ff::MontConfig;
 use zkhash::ark_ff::One;
 use zkhash::ark_ff::UniformRand;
 use zkhash::ark_ff::Zero;
-use zkhash::poseidon2::poseidon2_instance_babybear::POSEIDON2_BABYBEAR_24_PARAMS;
+use zkhash::poseidon2::poseidon2_instance_babybear::{POSEIDON2_BABYBEAR_16_PARAMS,POSEIDON2_BABYBEAR_24_PARAMS};
 use zkhash::{
     fields::babybear::{FpBabyBear, FqConfig},
     poseidon2::poseidon2::Poseidon2,
@@ -277,6 +277,7 @@ impl<
 
         let l = message.len();
         let instance = Poseidon2::new(&POSEIDON2_BABYBEAR_24_PARAMS);
+        let instance_short = Poseidon2::new(&POSEIDON2_BABYBEAR_16_PARAMS);
         if l == 1 {
             // we compress parameter, tweak, message
             let message_unpacked = message[0];
@@ -287,7 +288,7 @@ impl<
                 .chain(message_unpacked.iter())
                 .cloned()
                 .collect();
-            return poseidon_compress::<HASH_LEN>(&instance, &combined_input);
+            return poseidon_compress::<HASH_LEN>(&instance_short, &combined_input);
         }
         if l == 2 {
             // we compress parameter, tweak, message (now containing two parts)

--- a/src/symmetric/tweak_hash/poseidon.rs
+++ b/src/symmetric/tweak_hash/poseidon.rs
@@ -1,0 +1,376 @@
+use zkhash::ark_ff::MontConfig;
+use zkhash::ark_ff::One;
+use zkhash::ark_ff::UniformRand;
+use zkhash::ark_ff::Zero;
+use zkhash::poseidon2::poseidon2_instance_babybear::POSEIDON2_BABYBEAR_24_PARAMS;
+use zkhash::{
+    fields::babybear::{FpBabyBear, FqConfig},
+    poseidon2::poseidon2::Poseidon2,
+};
+
+use num_bigint::BigUint;
+
+use super::TweakableHash;
+
+// TODO: Check if we want to use this field or a different one
+type F = FpBabyBear;
+
+/// Enum to implement tweaks.
+pub enum PoseidonTweak<
+    const LOG_LIFETIME: usize,
+    const CEIL_LOG_NUM_CHAINS: usize,
+    const CHUNK_SIZE: usize,
+> {
+    TreeTweak {
+        level: u8,
+        pos_in_level: u32,
+    },
+    ChainTweak {
+        epoch: u32,
+        chain_index: u16,
+        pos_in_chain: u16,
+    },
+    _Marker(std::marker::PhantomData<F>),
+}
+
+impl<const LOG_LIFETIME: usize, const CEIL_LOG_NUM_CHAINS: usize, const CHUNK_SIZE: usize>
+    PoseidonTweak<LOG_LIFETIME, CEIL_LOG_NUM_CHAINS, CHUNK_SIZE>
+{
+    //const TWEAK_LEN: usize = 6;
+
+    fn to_field_elements<const TWEAK_LEN: usize>(&self) -> Vec<F> {
+        // we need to convert from integers to field elements,
+        // Note: taking into account the constants
+        // LOG_LIFETIME, CEIL_LOG_NUM_CHAINS, CHUNK_SIZE,
+        // we know that the tweak can be represented using at most
+        // LOG_LIFETIME + CEIL_LOG_NUM_CHAINS + CHUNK_SIZE many
+        // bits.
+
+        let tweak_bigint = match self {
+            PoseidonTweak::TreeTweak {
+                level,
+                pos_in_level,
+            } => {
+                (BigUint::from(*level) << 40)
+                    + (BigUint::from(*pos_in_level) << 8)
+                    + crate::TWEAK_SEPARATOR_FOR_TREE_HASH
+            }
+            PoseidonTweak::ChainTweak {
+                epoch,
+                chain_index,
+                pos_in_chain,
+            } => {
+                (BigUint::from(*epoch) << 40)
+                    + (BigUint::from(*chain_index) << 24)
+                    + (BigUint::from(*pos_in_chain) << 8)
+                    + crate::TWEAK_SEPARATOR_FOR_CHAIN_HASH
+            }
+            _ => BigUint::from(0 as u32),
+        };
+        let mut tweak_fe: [F; TWEAK_LEN] = [F::zero(); TWEAK_LEN];
+        tweak_fe.iter_mut().fold(tweak_bigint, |acc, item| {
+            let tmp = acc.clone() % BigUint::from(FqConfig::MODULUS);
+            *item = F::from(tmp.clone());
+            (acc - tmp) / (BigUint::from(FqConfig::MODULUS))
+        }); //interpreting the number base-p
+        tweak_fe.to_vec()
+    }
+}
+
+/// Function to first pad input to appropriate length and
+/// then apply the Poseidon permutation.
+fn poseidon_padded_permute(instance: &Poseidon2<F>, input: &[F]) -> Vec<F> {
+    assert!(
+        input.len() <= instance.get_t(),
+        "Poseidon Compression: Input length too large for Poseidon parameters."
+    );
+
+    // pad input with zeroes to have exactly length instance.get_t()
+    let mut padded_input = input.to_vec();
+    padded_input.resize_with(instance.get_t(), F::zero);
+
+    // apply permutation and return
+    instance.permutation(&padded_input)
+}
+
+/// Poseidon Compression Function, using the Poseidon Permutation.
+/// It works as PoseidonCompress(x) = Truncate(PoseidonPermute(x) + x)
+pub fn poseidon_compress<const OUT_LEN: usize>(
+    instance: &Poseidon2<F>,
+    input: &[F],
+) -> [F; OUT_LEN] {
+    assert!(
+        input.len() >= OUT_LEN,
+        "Poseidon Compression: Input length must be at least output length."
+    );
+
+    // first permute input
+    let permuted_input = poseidon_padded_permute(instance, input);
+    // now, add them, but only for the positions
+    // we actually output.
+    let mut output = [F::zero(); OUT_LEN];
+    for i in 0..OUT_LEN {
+        output[i] = permuted_input[i] + input[i];
+    }
+    output
+}
+
+///Construct a domain separator based on @params array of usize treated as u32.
+///It should fit the Poseidon instance
+
+pub fn poseidon_safe_domain_separator<const OUT_LEN: usize>(
+    instance: &Poseidon2<F>,
+    params: &[usize],
+) -> [F; OUT_LEN] {
+    let state_bits = f64::log2(
+        BigUint::from(FqConfig::MODULUS)
+            .to_string()
+            .parse()
+            .unwrap(),
+    ) * f64::from(instance.get_t() as u32);
+    assert!(
+        state_bits >= f64::from((params.len() * 32) as u32),
+        "Parameter mismatch: not enough field elements to hash the domain separator"
+    );
+
+    let domain_uint = params.iter().fold(BigUint::ZERO, |acc, &item| {
+        acc * BigUint::from(((1 as u64) << 32) as u64) + (item as u32)
+    }); //collect the vector into a number
+
+    //Creating a Poseidon input
+    let mut input = vec![F::zero(); instance.get_t()];
+    input.iter_mut().fold(domain_uint, |acc, item| {
+        let tmp = acc.clone() % BigUint::from(FqConfig::MODULUS);
+        *item = F::from(tmp.clone());
+        (acc - tmp) / (BigUint::from(FqConfig::MODULUS))
+    }); //interpreting the number base-p
+    poseidon_compress::<OUT_LEN>(instance, &input)
+}
+
+///Poseidon Sponge hash
+///Takes input of arbitrary length
+///Capacity must hold an appropriate domain separator, e.g. hash of the lengths
+pub fn poseidon_sponge<const OUT_LEN: usize>(
+    instance: &Poseidon2<F>,
+    capacity_value: &[F],
+    input: &[F],
+) -> [F; OUT_LEN] {
+    //capacity must be shorter than the width
+    assert!(
+        capacity_value.len() < instance.get_t(),
+        "Poseidon Sponge: Capacity must be smaller than the state size."
+    );
+
+    let rate = instance.get_t() - capacity_value.len();
+
+    let extra_elements = (rate - (input.len() % rate)) % rate;
+    let mut input_vector = input.to_vec().clone();
+    input_vector.resize_with(extra_elements, F::zero); //padding with 0s
+
+    //Initialize
+    let mut state = vec![F::zero(); rate];
+    state.extend_from_slice(capacity_value);
+    //Absorb
+    for chunk in input_vector.chunks(rate) {
+        for i in 0..chunk.len() {
+            state[i] = state[i] + chunk[i];
+            instance.permutation(&state);
+        }
+    }
+    //Squeeze
+    let mut out = vec![];
+    while out.len() < OUT_LEN {
+        out.extend_from_slice(&state[..rate]);
+        instance.permutation(&state);
+    }
+    let slice = &out[0..OUT_LEN];
+    slice.try_into().expect("Length mismatch")
+}
+
+/// A tweakable hash function implemented using Poseidon2
+///
+/// Note: HASH_LEN and PARAMETER_LEN must be given in
+/// the unit "number of field elements".
+pub struct PoseidonTweakHash<
+    const LOG_LIFETIME: usize,
+    const CEIL_LOG_NUM_CHAINS: usize,
+    const CHUNK_SIZE: usize,
+    const PARAMETER_LEN: usize,
+    const HASH_LEN: usize,
+    const TWEAK_LEN: usize,
+    const CAPACITY: usize,
+    const NUM_CHUNKS: usize,
+>;
+
+impl<
+        const LOG_LIFETIME: usize,
+        const CEIL_LOG_NUM_CHAINS: usize,
+        const CHUNK_SIZE: usize,
+        const PARAMETER_LEN: usize,
+        const HASH_LEN: usize,
+        const TWEAK_LEN: usize,
+        const CAPACITY: usize,
+        const NUM_CHUNKS: usize,
+    > TweakableHash
+    for PoseidonTweakHash<
+        LOG_LIFETIME,
+        CEIL_LOG_NUM_CHAINS,
+        CHUNK_SIZE,
+        PARAMETER_LEN,
+        HASH_LEN,
+        TWEAK_LEN,
+        CAPACITY,
+        NUM_CHUNKS,
+    >
+{
+    type Parameter = [F; PARAMETER_LEN];
+
+    type Tweak = PoseidonTweak<LOG_LIFETIME, CEIL_LOG_NUM_CHAINS, CHUNK_SIZE>;
+
+    type Domain = [F; HASH_LEN];
+
+    fn rand_parameter<R: rand::Rng>(rng: &mut R) -> Self::Parameter {
+        let mut par = [F::one(); PARAMETER_LEN];
+        for i in 0..PARAMETER_LEN {
+            par[i] = F::rand(rng);
+        }
+        par
+    }
+
+    fn rand_domain<R: rand::Rng>(rng: &mut R) -> Self::Domain {
+        let mut dom = [F::one(); HASH_LEN];
+        for i in 0..HASH_LEN {
+            dom[i] = F::rand(rng);
+        }
+        dom
+    }
+
+    fn tree_tweak(level: u8, pos_in_level: u32) -> Self::Tweak {
+        PoseidonTweak::TreeTweak {
+            level,
+            pos_in_level,
+        }
+    }
+
+    fn chain_tweak(epoch: u32, chain_index: u16, pos_in_chain: u16) -> Self::Tweak {
+        PoseidonTweak::ChainTweak {
+            epoch,
+            chain_index,
+            pos_in_chain,
+        }
+    }
+
+    fn apply(
+        parameter: &Self::Parameter,
+        tweak: &Self::Tweak,
+        message: &[Self::Domain],
+    ) -> Self::Domain {
+        assert!(
+            PARAMETER_LEN + TWEAK_LEN + 2 * HASH_LEN <= 24,
+            "Poseidon Tweak Hash: Input lengths too large for Poseidon instance"
+        );
+
+        // we are in one of three cases:
+        // (1) hashing within chains. We use compression mode.
+        // (2) hashing two siblings in the tree. We use compression mode.
+        // (3) hashing a long vector of chain ends. We use sponge mode.
+
+        let l = message.len();
+        let instance = Poseidon2::new(&POSEIDON2_BABYBEAR_24_PARAMS);
+        if l == 1 {
+            // we compress parameter, tweak, message
+            let message_unpacked = message[0];
+            let tweak_fe = PoseidonTweak::to_field_elements::<TWEAK_LEN>(tweak);
+            let combined_input: Vec<F> = parameter
+                .iter()
+                .chain(tweak_fe.iter())
+                .chain(message_unpacked.iter())
+                .cloned()
+                .collect();
+            return poseidon_compress::<HASH_LEN>(&instance, &combined_input);
+        }
+        if l == 2 {
+            // we compress parameter, tweak, message (now containing two parts)
+            let message_unpacked_left = message[0];
+            let message_unpacked_right = message[1];
+            let tweak_fe = PoseidonTweak::to_field_elements::<TWEAK_LEN>(tweak);
+            let combined_input: Vec<F> = parameter
+                .iter()
+                .chain(tweak_fe.iter())
+                .chain(message_unpacked_left.iter())
+                .chain(message_unpacked_right.iter())
+                .cloned()
+                .collect();
+            return poseidon_compress::<HASH_LEN>(&instance, &combined_input);
+        }
+        if l > 2 {
+            let tweak_fe = PoseidonTweak::to_field_elements::<TWEAK_LEN>(tweak);
+            let combined_input: Vec<F> = parameter
+                .iter()
+                .chain(tweak_fe.iter())
+                .chain(message.iter().flat_map(|sub_arr| sub_arr.iter()))
+                .cloned()
+                .collect();
+            let lengths = [PARAMETER_LEN, TWEAK_LEN, NUM_CHUNKS, HASH_LEN];
+            let safe_input = poseidon_safe_domain_separator::<CAPACITY>(&instance, &lengths);
+            let capacity_value = poseidon_compress::<CAPACITY>(&instance, &safe_input);
+            let res = poseidon_sponge(&instance, &capacity_value, &combined_input);
+            return res;
+        }
+        // will never be reached
+        [F::one(); HASH_LEN]
+    }
+}
+
+// Example instantiations
+pub type PoseidonTweak44 = PoseidonTweakHash<20, 8, 2, 4, 4, 3, 9, 128>;
+pub type PoseidonTweak37 = PoseidonTweakHash<20, 8, 2, 3, 7, 3, 9, 128>;
+
+#[cfg(test)]
+mod tests {
+    use rand::thread_rng;
+
+    use super::*;
+
+    #[test]
+    fn test_apply_44() {
+        let mut rng = thread_rng();
+
+        // test that nothing is panicking
+        let parameter = PoseidonTweak44::rand_parameter(&mut rng);
+        let message_one = PoseidonTweak44::rand_domain(&mut rng);
+        let message_two = PoseidonTweak44::rand_domain(&mut rng);
+        let tweak_tree = PoseidonTweak44::tree_tweak(0, 3);
+        PoseidonTweak44::apply(&parameter, &tweak_tree, &[message_one, message_two]);
+
+        // test that nothing is panicking
+        let parameter = PoseidonTweak44::rand_parameter(&mut rng);
+        let message_one = PoseidonTweak44::rand_domain(&mut rng);
+        let tweak_chain = PoseidonTweak44::chain_tweak(2, 3, 4);
+        PoseidonTweak44::apply(&parameter, &tweak_chain, &[message_one]);
+
+        // test that nothing is panicking
+        let parameter = PoseidonTweak44::rand_parameter(&mut rng);
+        let chains = [PoseidonTweak44::rand_domain(&mut rng); 128];
+        let tweak_tree = PoseidonTweak44::tree_tweak(0, 3);
+        PoseidonTweak44::apply(&parameter, &tweak_tree, &chains);
+    }
+
+    #[test]
+    fn test_apply_37() {
+        let mut rng = thread_rng();
+
+        // test that nothing is panicking
+        let parameter = PoseidonTweak37::rand_parameter(&mut rng);
+        let message_one = PoseidonTweak37::rand_domain(&mut rng);
+        let message_two = PoseidonTweak37::rand_domain(&mut rng);
+        let tweak_tree = PoseidonTweak37::tree_tweak(0, 3);
+        PoseidonTweak37::apply(&parameter, &tweak_tree, &[message_one, message_two]);
+
+        // test that nothing is panicking
+        let parameter = PoseidonTweak37::rand_parameter(&mut rng);
+        let message_one = PoseidonTweak37::rand_domain(&mut rng);
+        let tweak_chain = PoseidonTweak37::chain_tweak(2, 3, 4);
+        PoseidonTweak37::apply(&parameter, &tweak_chain, &[message_one]);
+    }
+}

--- a/src/symmetric/tweak_hash/sha.rs
+++ b/src/symmetric/tweak_hash/sha.rs
@@ -87,7 +87,7 @@ impl<const PARAMETER_LEN: usize, const HASH_LEN: usize> TweakableHash
     }
  
     fn chain_tweak(epoch: u32, chain_index: u16, pos_in_chain: u16) -> Self::Tweak {
-        Sha256Tweak::ChainTweak { 
+        ShaTweak::ChainTweak { 
             epoch,
             chain_index,
             pos_in_chain,

--- a/src/symmetric/tweak_hash/sha.rs
+++ b/src/symmetric/tweak_hash/sha.rs
@@ -85,9 +85,9 @@ impl<const PARAMETER_LEN: usize, const HASH_LEN: usize> TweakableHash
             pos_in_level,
         }
     }
- 
+
     fn chain_tweak(epoch: u32, chain_index: u16, pos_in_chain: u16) -> Self::Tweak {
-        ShaTweak::ChainTweak { 
+        ShaTweak::ChainTweak {
             epoch,
             chain_index,
             pos_in_chain,

--- a/src/symmetric/tweak_hash/sha.rs
+++ b/src/symmetric/tweak_hash/sha.rs
@@ -10,8 +10,8 @@ pub enum ShaTweak {
     },
     ChainTweak {
         epoch: u32,
-        chain_index: u32,
-        pos_in_chain: u32,
+        chain_index: u16,
+        pos_in_chain: u16,
     },
 }
 
@@ -85,9 +85,9 @@ impl<const PARAMETER_LEN: usize, const HASH_LEN: usize> TweakableHash
             pos_in_level,
         }
     }
-
-    fn chain_tweak(epoch: u32, chain_index: u32, pos_in_chain: u32) -> Self::Tweak {
-        ShaTweak::ChainTweak {
+ 
+    fn chain_tweak(epoch: u32, chain_index: u16, pos_in_chain: u16) -> Self::Tweak {
+        Sha256Tweak::ChainTweak { 
             epoch,
             chain_index,
             pos_in_chain,

--- a/src/symmetric/tweak_hash/sha.rs
+++ b/src/symmetric/tweak_hash/sha.rs
@@ -99,15 +99,6 @@ impl<const PARAMETER_LEN: usize, const HASH_LEN: usize> TweakableHash
         tweak: &Self::Tweak,
         message: &[Self::Domain],
     ) -> Self::Domain {
-        assert!(
-            PARAMETER_LEN < 256 / 8,
-            "SHA Tweak Hash: Parameter Length must be less than 256 bit"
-        );
-        assert!(
-            HASH_LEN < 256 / 8,
-            "SHA Tweak Hash: Hash Length must be less than 256 bit"
-        );
-
         let mut hasher = Sha3_256::new();
 
         // add the parameter and tweak
@@ -122,6 +113,18 @@ impl<const PARAMETER_LEN: usize, const HASH_LEN: usize> TweakableHash
         // finalize the hash, and take as many bytes as we need
         let result = hasher.finalize();
         result[0..HASH_LEN].try_into().unwrap()
+    }
+
+    fn consistency_check() -> bool {
+        assert!(
+            PARAMETER_LEN < 256 / 8,
+            "SHA Tweak Hash: Parameter Length must be less than 256 bit"
+        );
+        assert!(
+            HASH_LEN < 256 / 8,
+            "SHA Tweak Hash: Hash Length must be less than 256 bit"
+        );
+        true
     }
 }
 
@@ -139,6 +142,8 @@ mod tests {
     #[test]
     fn test_apply_128_128() {
         let mut rng = thread_rng();
+
+        ShaTweak128128::consistency_check();
 
         // test that nothing is panicking
         let parameter = ShaTweak128128::rand_parameter(&mut rng);
@@ -158,6 +163,8 @@ mod tests {
     #[test]
     fn test_apply_128_192() {
         let mut rng = thread_rng();
+
+        ShaTweak128192::consistency_check();
 
         // test that nothing is panicking
         let parameter = ShaTweak128192::rand_parameter(&mut rng);


### PR DESCRIPTION
- Added num-bigint dependency
- Chain lengths and indices are now u16 to have a smaller tweak
- MESSAGE_LENGTH changed to 32 for smaller hash
- Tweak separator values added
- Poseidon Message Hash now has TWEAK_LEN_FE and MSG_LEN_FE parameters
- Message encoded for hashing in Poseidon message hash
- Epoch/tweak encoded for hashing in Poseidon message hash
- Poseidon message hash decoded to chunks
- Poseidon Tweakable Hash now has TWEAK_LEN, CAPACITY, and NUM_CHUNKS parameter
- Tweak to FE functions constructed for Poseidon
- Domain separator function for Poseidon SAFE Sponge
- Tweakable hashing for leafs implemented via Poseidon SAFE Sponge
- Small test added for leaf hashing
- Consistency check function in TH traits