### PR TITLE
Naively parallelize keygen with `rayon`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ rand = "0.8.5"
 sha3 = "0.10.8"
 zkhash = { git = "https://github.com/HorizenLabs/poseidon2", branch = "main", package = "zkhash" }
 num-bigint = "0.4.6"
+rayon = "1.10.0"
 
 [dev-dependencies]
 criterion = "0.4"

--- a/src/signature/generalized_xmss.rs
+++ b/src/signature/generalized_xmss.rs
@@ -97,10 +97,12 @@ where
         let num_chains = IE::NUM_CHUNKS;
         let chain_length = 1 << IE::CHUNK_SIZE;
 
+        // parallelize the chain ends hash computation for each epoch
         let chain_ends_hashes = (0..Self::LIFETIME)
             .into_par_iter()
             .map(|epoch| {
                 // each epoch has a number of chains
+                // parallelize the chain ends computation for each chain
                 let chain_ends = (0..num_chains)
                     .into_par_iter()
                     .map(|chain_index| {

--- a/src/signature/generalized_xmss.rs
+++ b/src/signature/generalized_xmss.rs
@@ -1,4 +1,5 @@
 use rand::Rng;
+use rayon::prelude::*;
 
 use crate::{
     inc_encoding::IncomparableEncoding,
@@ -95,38 +96,34 @@ where
         // chain starting at the secret key.
         let num_chains = IE::NUM_CHUNKS;
         let chain_length = 1 << IE::CHUNK_SIZE;
-        let mut chain_starts = Vec::with_capacity(Self::LIFETIME as usize);
-        let mut chain_ends = Vec::with_capacity(Self::LIFETIME as usize);
 
-        for epoch in 0..Self::LIFETIME {
-            let mut epoch_chain_starts = Vec::with_capacity(num_chains);
-            let mut epoch_chain_ends = Vec::with_capacity(num_chains);
+        let chain_ends_hashes = (0..Self::LIFETIME)
+            .into_par_iter()
+            .map(|epoch| {
+                // each epoch has a number of chains
+                let chain_ends = (0..num_chains)
+                    .into_par_iter()
+                    .map(|chain_index| {
+                        // each chain start is just a PRF evaluation
+                        let start = PRF::apply(&prf_key, epoch as u32, chain_index as u64).into();
+                        // walk the chain to get the public chain end
+                        chain::<TH>(
+                            &parameter,
+                            epoch as u32,
+                            chain_index as u16,
+                            0,
+                            chain_length - 1,
+                            &start,
+                        )
+                    })
+                    .collect::<Vec<_>>();
+                // build hash of chain ends / public keys
+                TH::apply(&parameter, &TH::tree_tweak(0, epoch as u32), &chain_ends)
+            })
+            .collect::<Vec<_>>();
 
-            // each epoch has a number of chains
-            for chain_index in 0..num_chains {
-                // each chain start is just a PRF evaluation
-                let start = PRF::apply(&prf_key, epoch as u32, chain_index as u64).into();
-                // walk the chain to get the public chain end
-                let end = chain::<TH>(
-                    &parameter,
-                    epoch as u32,
-                    chain_index as u16,
-                    0,
-                    chain_length - 1,
-                    &start,
-                );
-                // collect
-                epoch_chain_starts.push(start);
-                epoch_chain_ends.push(end);
-            }
-            chain_starts.push(epoch_chain_starts);
-            chain_ends.push(epoch_chain_ends);
-        }
-
-        // now build a Merkle tree on top of these chain ends / public keys
-        let chain_ends_slices: Vec<&[TH::Domain]> =
-            chain_ends.iter().map(|v| v.as_slice()).collect();
-        let tree = build_tree(&parameter, &chain_ends_slices);
+        // now build a Merkle tree on top of the hashes of chain ends / public keys
+        let tree = build_tree(&parameter, chain_ends_hashes);
         let root = hash_tree_root(&tree);
 
         // assemble public key and secret key

--- a/src/symmetric/prf.rs
+++ b/src/symmetric/prf.rs
@@ -2,7 +2,7 @@ use rand::Rng;
 
 /// Trait to model a pseudorandom function
 pub trait Pseudorandom {
-    type Key;
+    type Key: Send + Sync;
     type Output;
 
     /// Sample a random domain element

--- a/src/symmetric/tweak_hash.rs
+++ b/src/symmetric/tweak_hash.rs
@@ -13,9 +13,9 @@ use rand::Rng;
 /// to obtain distinct tweaks for applications in chains and
 /// applications in Merkle trees.
 pub trait TweakableHash {
-    type Parameter: Copy + Sized;
+    type Parameter: Copy + Sized + Send + Sync;
     type Tweak;
-    type Domain: Copy + PartialEq + Sized;
+    type Domain: Copy + PartialEq + Sized + Send + Sync;
 
     /// Generates a random public parameter.
     fn rand_parameter<R: Rng>(rng: &mut R) -> Self::Parameter;

--- a/src/symmetric/tweak_hash_tree.rs
+++ b/src/symmetric/tweak_hash_tree.rs
@@ -34,6 +34,7 @@ pub fn build_tree<TH: TweakableHash>(
     while layer_size >= 2 {
         // this new layer will have half the size
         layer_size = layer_size / 2;
+        // parallelize the two to one compressions
         layers.push(
             (0..layer_size)
                 .into_par_iter()


### PR DESCRIPTION
Add dependency `rayon` and

1. For `build_tree`
    1. Change API to receive hashes of leafs directly.
    1. Parallelize 2-1 compressions in each layer.
1. For `GeneralizedXMSSSignatureScheme::gen`
    1. Parallelize `chain_ends_hashes` compuation
    1. Parallelize each `chain_ends` computation
    1. Compute hash of `chain_ends` immediately to save memory usage (should reduce memory usage to `1 / NUM_CHUNKS`).

All these make `GeneralizedXMSSSignatureScheme::gen` roughly 7x faster with 12 threads, and 9x faster with 24 threads than single thread.