### PR TITLE
`to_field_elements`: accelerate and unit tests

### DIFF
--- a/src/symmetric/tweak_hash/poseidon.rs
+++ b/src/symmetric/tweak_hash/poseidon.rs
@@ -1,4 +1,3 @@
-use std::mem::MaybeUninit;
 use zkhash::ark_ff::MontConfig;
 use zkhash::ark_ff::One;
 use zkhash::ark_ff::UniformRand;
@@ -78,16 +77,11 @@ impl<const LOG_LIFETIME: usize, const CEIL_LOG_NUM_CHAINS: usize, const CHUNK_SI
         let p = FqConfig::MODULUS.0[0] as u128;
 
         // Now we interpret this integer in base-p to get field elements
-        let mut out: [MaybeUninit<F>; TWEAK_LEN] = unsafe { MaybeUninit::uninit().assume_init() };
-
-        for i in 0..TWEAK_LEN {
+        std::array::from_fn(|_| {
             let digit = acc % p;
             acc /= p;
-            out[i] = MaybeUninit::new(F::from(digit));
-        }
-
-        // SAFETY: all elements initialized above
-        unsafe { std::mem::transmute_copy::<_, [F; TWEAK_LEN]>(&out) }
+            F::from(digit)
+        })
     }
 }
 

--- a/src/symmetric/tweak_hash/poseidon.rs
+++ b/src/symmetric/tweak_hash/poseidon.rs
@@ -74,6 +74,8 @@ impl<const LOG_LIFETIME: usize, const CEIL_LOG_NUM_CHAINS: usize, const CHUNK_SI
         };
 
         // Get the modulus
+        //
+        // This is fine to take only the first limb as we are using prime fields with <= 64 bits
         let p = FqConfig::MODULUS.0[0] as u128;
 
         // Now we interpret this integer in base-p to get field elements
@@ -304,6 +306,10 @@ impl<
 
     #[cfg(test)]
     fn internal_consistency_check() {
+        assert!(
+            BigUint::from(FqConfig::MODULUS) < BigUint::from(u64::MAX),
+            "The prime field used is too large"
+        );
         assert!(
             CAPACITY < 24,
             "Poseidon Tweak Chain Hash: Capacity must be less than 24"


### PR DESCRIPTION
After profiling this function with a sample, I noticed a few areas that slowed things down a bit. I noticed some optimizations to be made:
- Currently, the type returned by the function was a vector that comes from an array (which is then transformed into a vector). To avoid unnecessary allocation and simplify, I think it's better to return an array directly (this doesn't change the rest of the code).
- The `tweak_fe` array was initially initialized with only zeros before overwriting each one during the base `p` decomposition. For this, there's this little trick where we can use `MaybeUninit` to just allocate without initializing the values.
- Finally, using `BigUint` is particularly expensive because it's an underlying vector that is allocated each time and whose dimensions are unknown in advance. Allocation and operations on it are therefore expensive. Since we're almost certain to use a prime field up to 64 bits max, I propose this solution here, which consists of simply using the first limb of the module to avoid using `BigUint` at all.
- I also added unit tests with various cases (including one case with maximum values) to make sure everything is correct and nothing is broken.

I ran a small benchmark to test this; I don't think it's useful to add this micro benchmark for this small function, but here it is as a reference:

```rust
use criterion::{black_box, criterion_group, criterion_main, Criterion};
use hashsig::symmetric::tweak_hash::poseidon::PoseidonTweak;
use hashsig::TWEAK_SEPARATOR_FOR_CHAIN_HASH;
use hashsig::TWEAK_SEPARATOR_FOR_TREE_HASH;
use num_bigint::BigUint;
use zkhash::fields::babybear::{FpBabyBear as F, FqConfig};

const TWEAK_LEN: usize = 3;
const TREE_SEP: u64 = TWEAK_SEPARATOR_FOR_TREE_HASH as u64;
const CHAIN_SEP: u64 = TWEAK_SEPARATOR_FOR_CHAIN_HASH as u64;

fn bench_tree_tweak(c: &mut Criterion) {
    let tweak = PoseidonTweak::<20, 8, 2>::TreeTweak {
        level: 42,
        pos_in_level: 12345,
    };

    c.bench_function("tree_tweak_to_field_elements", |b| {
        b.iter(|| {
            let _ = tweak.to_field_elements::<TWEAK_LEN>();
        })
    });
}

fn bench_chain_tweak(c: &mut Criterion) {
    let tweak = PoseidonTweak::<20, 8, 2>::ChainTweak {
        epoch: 1337,
        chain_index: 12,
        pos_in_chain: 34,
    };

    c.bench_function("chain_tweak_to_field_elements", |b| {
        b.iter(|| {
            let _ = tweak.to_field_elements::<TWEAK_LEN>();
        })
    });
}

criterion_group!(tweak_benches, bench_tree_tweak, bench_chain_tweak);
criterion_main!(tweak_benches);
```

On this benchmark, I've observed a speedup of 99% compared to the original version of the function.

I've a more conservative version of this PR, keeping `BigUint` in case we're not confident that we'll ever use prime fields with modules with more than 64 bits.