### PR TITLE
`encode_message`: accelerate fn and unit tests

### DIFF
--- a/src/symmetric/message_hash/poseidon.rs
+++ b/src/symmetric/message_hash/poseidon.rs
@@ -20,7 +20,7 @@ fn encode_message<const MSG_LEN_FE: usize>(message: &[u8; MESSAGE_LENGTH]) -> [F
     // Interpret message as a little-endian integer
     let mut acc = BigUint::from_bytes_le(message);
 
-    // Get the BabyBear modulus as BigUint once
+    // Get the modulus as BigUint once
     let p = BigUint::from(FqConfig::MODULUS);
 
     // Perform base-p decomposition

--- a/src/symmetric/message_hash/poseidon.rs
+++ b/src/symmetric/message_hash/poseidon.rs
@@ -15,19 +15,20 @@ use crate::TWEAK_SEPARATOR_FOR_MESSAGE_HASH;
 
 type F = FpBabyBear;
 
-/// Function to encode a message as a vector of field elements
+/// Function to encode a message as an array of field elements
 fn encode_message<const MSG_LEN_FE: usize>(message: &[u8; MESSAGE_LENGTH]) -> [F; MSG_LEN_FE] {
-    // convert the bytes into a number
-    let message_uint = BigUint::from_bytes_le(message);
+    // Interpret message as a little-endian integer
+    let mut acc = BigUint::from_bytes_le(message);
 
-    // now interpret the number in base-p
-    let mut message_fe: [F; MSG_LEN_FE] = [F::zero(); MSG_LEN_FE];
-    message_fe.iter_mut().fold(message_uint, |acc, item| {
-        let tmp = acc.clone() % BigUint::from(FqConfig::MODULUS);
-        *item = F::from(tmp.clone());
-        (acc - tmp) / (BigUint::from(FqConfig::MODULUS))
-    });
-    message_fe
+    // Get the BabyBear modulus as BigUint once
+    let p = BigUint::from(FqConfig::MODULUS);
+
+    // Perform base-p decomposition
+    std::array::from_fn(|_| {
+        let digit = &acc % &p;
+        acc /= &p;
+        F::from(digit)
+    })
 }
 
 /// Function to encode an epoch (= tweak in the message hash)
@@ -198,6 +199,7 @@ pub type PoseidonMessageHashW1 = PoseidonMessageHash<5, 5, 5, 163, 1, 2, 9>;
 mod tests {
     use super::*;
     use rand::{thread_rng, Rng};
+    use zkhash::ark_ff::Field;
     use zkhash::ark_ff::One;
     use zkhash::ark_ff::UniformRand;
 
@@ -261,5 +263,80 @@ mod tests {
             "rand generated identical elements in all {} trials",
             K
         );
+    }
+
+    #[test]
+    fn test_encode_message_all_zeros() {
+        // Message
+        let message = [0u8; 32];
+
+        // Expected = 9 zeros
+        let expected = [F::ZERO; 9];
+
+        let computed = super::encode_message::<9>(&message);
+        assert_eq!(computed, expected);
+    }
+
+    #[test]
+    fn test_encode_message_all_max() {
+        // Message
+        let message = [u8::MAX; 32];
+
+        // Convert to bigint
+        let message_bigint = BigUint::from_bytes_le(&message);
+
+        // Field modulus
+        let p = BigUint::from(FqConfig::MODULUS);
+
+        // Compute expected: base-p decomposition
+        //
+        // We compute this by hand to ensure that the test is correct.
+        let expected = [
+            F::from(&message_bigint % &p),
+            F::from((&message_bigint / &p) % &p),
+            F::from((&message_bigint / (&p * &p)) % &p),
+            F::from((&message_bigint / (&p * &p * &p)) % &p),
+            F::from((&message_bigint / (&p * &p * &p * &p)) % &p),
+            F::from((&message_bigint / (&p * &p * &p * &p * &p)) % &p),
+            F::from((&message_bigint / (&p * &p * &p * &p * &p * &p)) % &p),
+            F::from((&message_bigint / (&p * &p * &p * &p * &p * &p * &p)) % &p),
+            F::from((&message_bigint / (&p * &p * &p * &p * &p * &p * &p * &p)) % &p),
+        ];
+
+        let computed = super::encode_message::<9>(&message);
+        assert_eq!(computed, expected);
+    }
+
+    #[test]
+    fn test_encode_message_mixed_bytes() {
+        // Alternating 0x00 and 0xFF
+        let mut message = [0u8; 32];
+        for (i, byte) in message.iter_mut().enumerate() {
+            *byte = if i % 2 == 0 { 0x00 } else { 0xFF };
+        }
+
+        // Convert to bigint
+        let message_bigint = BigUint::from_bytes_le(&message);
+
+        // Field modulus
+        let p = BigUint::from(FqConfig::MODULUS);
+
+        // Compute expected: base-p decomposition
+        //
+        // We compute this by hand to ensure that the test is correct.
+        let expected = [
+            F::from(&message_bigint % &p),
+            F::from((&message_bigint / &p) % &p),
+            F::from((&message_bigint / (&p * &p)) % &p),
+            F::from((&message_bigint / (&p * &p * &p)) % &p),
+            F::from((&message_bigint / (&p * &p * &p * &p)) % &p),
+            F::from((&message_bigint / (&p * &p * &p * &p * &p)) % &p),
+            F::from((&message_bigint / (&p * &p * &p * &p * &p * &p)) % &p),
+            F::from((&message_bigint / (&p * &p * &p * &p * &p * &p * &p)) % &p),
+            F::from((&message_bigint / (&p * &p * &p * &p * &p * &p * &p * &p)) % &p),
+        ];
+
+        let computed = super::encode_message::<9>(&message);
+        assert_eq!(computed, expected);
     }
 }

--- a/src/symmetric/message_hash/poseidon.rs
+++ b/src/symmetric/message_hash/poseidon.rs
@@ -270,7 +270,7 @@ mod tests {
         // Message
         let message = [0u8; 32];
 
-        // Expected = 9 zeros
+        // Expected = 9 zeros, as 9 * 31 >= 8 * 32
         let expected = [F::ZERO; 9];
 
         let computed = super::encode_message::<9>(&message);


### PR DESCRIPTION
The goal of this PR is:
- To accelerate the function by avoiding some clones in the main loop and initialization with zeros.
- I've added some unit tests with manual computation of expected values ​​to make them readable and easily verifiable by hand.

I micro benchmarked this functions specifically with the following benchmark:
```rust
fn bench_encode_message(c: &mut Criterion) {
    // Create a random message of MESSAGE_LENGTH bytes
    let mut rng = thread_rng();
    let mut message = [0u8; MESSAGE_LENGTH];
    rng.fill(&mut message);


    c.bench_function("encode_message", |b| {
        b.iter(|| {
            let _ = encode_message::<3>(black_box(&message));
        })
    });
}

criterion_group!(benches, bench_encode_message);
criterion_main!(benches);
```

and I observed around 30% speedup compared to the original function.