### PR TITLE
`decode_to_chunks`: accelerate fn and unit tests

### DIFF
--- a/src/symmetric/message_hash/poseidon.rs
+++ b/src/symmetric/message_hash/poseidon.rs
@@ -55,7 +55,7 @@ fn encode_epoch<const TWEAK_LEN_FE: usize>(epoch: u32) -> [F; TWEAK_LEN_FE] {
 fn decode_to_chunks<const NUM_CHUNKS: usize, const CHUNK_SIZE: usize, const HASH_LEN_FE: usize>(
     field_elements: &[F; HASH_LEN_FE],
 ) -> [u8; NUM_CHUNKS] {
-    // Combine field elements into one big integer (little-endian base-p)
+    // Combine field elements into one big integer
     let p = BigUint::from(FqConfig::MODULUS);
     let mut acc = BigUint::ZERO;
     for fe in field_elements.iter() {

--- a/src/symmetric/message_hash/poseidon.rs
+++ b/src/symmetric/message_hash/poseidon.rs
@@ -283,16 +283,16 @@ mod tests {
 
         // Create field elements
         let input = [F::from(1u64), F::from(2u64)];
-        let hash_uint = BigUint::from(2u64) * &p + BigUint::from(1u64);
+        let input_uint = BigUint::from(2u64) * &p + BigUint::from(1u64);
 
         // CHUNK_SIZE = 4 => max value = 2^4 = 16
-        // Split hash_uint = 2p + 1 into base-16 digits (little endian)
+        // Split input_uint = 2p + 1 into base-16 digits (little endian)
         //
         // Example:
-        //   hash_uint = D_0 + 16*D_1 + 16^2*D_2 + ...
-        //   We compute D_i = hash_uint % 16, then divide by 16
+        //   input_uint = D_0 + 16*D_1 + 16^2*D_2 + ...
+        //   We compute D_i = input_uint % 16, then divide by 16
 
-        let mut acc = hash_uint.clone();
+        let mut acc = input_uint.clone();
         let mut expected = [0; 4];
         for i in 0..4 {
             expected[i] = (&acc % 16u8).try_into().unwrap();
@@ -311,9 +311,9 @@ mod tests {
         // Use all field elements set to p - 1
         let input = [F::from(p.clone() - 1u32); 3];
 
-        // Compute combined hash_uint:
+        // Compute combined input_uint:
         //
-        // hash_uint = (p - 1) + (p - 1) * p + (p - 1) * p^2
+        // input_uint = (p - 1) + (p - 1) * p + (p - 1) * p^2
         //           = (p^2 + p + 1) * (p - 1)
         //
         // We’ll expand it:
@@ -322,10 +322,10 @@ mod tests {
 
         let p2 = &p * &p;
         let p3 = &p * &p2;
-        let hash_uint = &p3 - 1u32;
+        let input_uint = &p3 - 1u32;
 
         // CHUNK_SIZE = 8 → max = 256
-        let mut acc = hash_uint.clone();
+        let mut acc = input_uint.clone();
         let mut expected = [0u8; 8];
         for i in 0..8 {
             expected[i] = (&acc % 256u32).try_into().unwrap();

--- a/src/symmetric/message_hash/poseidon.rs
+++ b/src/symmetric/message_hash/poseidon.rs
@@ -209,6 +209,7 @@ mod tests {
     use zkhash::ark_ff::Field;
     use zkhash::ark_ff::One;
     use zkhash::ark_ff::UniformRand;
+    use zkhash::ark_ff::Zero;
 
     #[test]
     fn test_apply() {
@@ -308,7 +309,10 @@ mod tests {
         }
 
         let result = decode_to_chunks::<4, 4, 2>(&input);
-  }    #[test]
+        assert_eq!(result, expected);
+    }
+
+    #[test]
     fn test_encode_epoch_small_value() {
         let epoch = 42u32;
         let sep = TWEAK_SEPARATOR_FOR_MESSAGE_HASH;
@@ -361,7 +365,10 @@ mod tests {
         }
 
         let result = decode_to_chunks::<8, 8, 3>(&input);
-  }    #[test]
+        assert_eq!(result, expected);
+    }
+
+    #[test]
     fn test_encode_epoch_zero() {
         let epoch = 0u32;
         let sep = TWEAK_SEPARATOR_FOR_MESSAGE_HASH;

--- a/src/symmetric/message_hash/poseidon.rs
+++ b/src/symmetric/message_hash/poseidon.rs
@@ -52,21 +52,21 @@ fn encode_epoch<const TWEAK_LEN_FE: usize>(epoch: u32) -> [F; TWEAK_LEN_FE] {
 /// CHUNK_SIZE up to 8 (inclusive) is supported
 fn decode_to_chunks<const NUM_CHUNKS: usize, const CHUNK_SIZE: usize, const HASH_LEN_FE: usize>(
     field_elements: &[F; HASH_LEN_FE],
-) -> Vec<u8> {
-    // Turn field elements into a big integer
-    let hash_uint = field_elements.iter().fold(BigUint::ZERO, |acc, &item| {
-        acc * BigUint::from(FqConfig::MODULUS) + BigUint::from(item.into_bigint())
-    });
+) -> [u8; NUM_CHUNKS] {
+    // Combine field elements into one big integer (little-endian base-p)
+    let p = BigUint::from(FqConfig::MODULUS);
+    let mut acc = BigUint::ZERO;
+    for fe in field_elements.iter().rev() {
+        acc = &acc * &p + BigUint::from(fe.into_bigint());
+    }
 
-    // Split the integer into chunks
-    let max_chunk_len = (1 << CHUNK_SIZE) as u16;
-
-    let mut hash_chunked: [u8; NUM_CHUNKS] = [0; NUM_CHUNKS];
-    hash_chunked.iter_mut().fold(hash_uint, |acc, item| {
-        *item = (acc.clone() % max_chunk_len).to_bytes_be()[0];
-        (acc - *item) / max_chunk_len
-    });
-    Vec::from(hash_chunked)
+    // Convert to base-(2^CHUNK_SIZE)
+    let base = (1 << CHUNK_SIZE) as u16;
+    std::array::from_fn(|_| {
+        let chunk = (&acc % base).try_into().unwrap();
+        acc /= base;
+        chunk
+    })
 }
 
 /// A message hash implemented using Poseidon2
@@ -147,7 +147,7 @@ impl<
         let hash_fe = poseidon_compress::<HASH_LEN_FE>(&instance, &combined_input);
 
         // decode field elements into chunks and return them
-        decode_to_chunks::<NUM_CHUNKS, CHUNK_SIZE, HASH_LEN_FE>(&hash_fe)
+        decode_to_chunks::<NUM_CHUNKS, CHUNK_SIZE, HASH_LEN_FE>(&hash_fe).to_vec()
     }
 
     #[cfg(test)]
@@ -198,6 +198,7 @@ pub type PoseidonMessageHashW1 = PoseidonMessageHash<5, 5, 5, 163, 1, 2, 9>;
 mod tests {
     use super::*;
     use rand::{thread_rng, Rng};
+    use zkhash::ark_ff::Field;
     use zkhash::ark_ff::One;
     use zkhash::ark_ff::UniformRand;
 
@@ -261,5 +262,76 @@ mod tests {
             "rand generated identical elements in all {} trials",
             K
         );
+    }
+
+    #[test]
+    fn test_decode_to_chunks_all_zeros() {
+        // All field elements are zero
+        let field_elements = [F::ZERO; 5];
+
+        // Should decode to all zero chunks
+        let expected = [0u8; 8];
+        let result = decode_to_chunks::<8, 4, 5>(&field_elements);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_decode_to_chunks_simple_value() {
+        // Field modulus
+        let p = BigUint::from(FqConfig::MODULUS);
+
+        // Create field elements
+        let input = [F::from(1u64), F::from(2u64)];
+        let hash_uint = BigUint::from(2u64) * &p + BigUint::from(1u64);
+
+        // CHUNK_SIZE = 4 → max value = 2^4 = 16
+        // Split hash_uint = 2p + 1 into base-16 digits (little endian)
+        //
+        // Example:
+        //   hash_uint = D_0 + 16*D_1 + 16^2*D_2 + ...
+        //   We compute D_i = hash_uint % 16, then divide by 16
+
+        let mut acc = hash_uint.clone();
+        let mut expected = [0; 4];
+        for i in 0..4 {
+            expected[i] = (&acc % 16u8).try_into().unwrap();
+            acc /= 16u8;
+        }
+
+        let result = decode_to_chunks::<4, 4, 2>(&input);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_decode_to_chunks_max_value() {
+        // Field modulus
+        let p = BigUint::from(FqConfig::MODULUS);
+
+        // Use all field elements set to p - 1
+        let input = [F::from(p.clone() - 1u32); 3];
+
+        // Compute combined hash_uint:
+        //
+        // hash_uint = (p - 1) + (p - 1) * p + (p - 1) * p^2
+        //           = (p^2 + p + 1) * (p - 1)
+        //
+        // We’ll expand it:
+        // = (p - 1) * (p^2 + p + 1)
+        // = p^3 - 1
+
+        let p2 = &p * &p;
+        let p3 = &p * &p2;
+        let hash_uint = &p3 - 1u32;
+
+        // CHUNK_SIZE = 8 → max = 256
+        let mut acc = hash_uint.clone();
+        let mut expected = [0u8; 8];
+        for i in 0..8 {
+            expected[i] = (&acc % 256u32).try_into().unwrap();
+            acc /= 256u32;
+        }
+
+        let result = decode_to_chunks::<8, 8, 3>(&input);
+        assert_eq!(result, expected);
     }
 }

--- a/src/symmetric/message_hash/poseidon.rs
+++ b/src/symmetric/message_hash/poseidon.rs
@@ -334,9 +334,9 @@ mod tests {
 
         let result = decode_to_chunks::<8, 8, 3>(&input);
         assert_eq!(result, expected);
-  }
-  
-      #[test]
+    }
+
+    #[test]
     fn test_encode_message_all_zeros() {
         // Message
         let message = [0u8; 32];

--- a/src/symmetric/message_hash/poseidon.rs
+++ b/src/symmetric/message_hash/poseidon.rs
@@ -285,7 +285,7 @@ mod tests {
         let input = [F::from(1u64), F::from(2u64)];
         let hash_uint = BigUint::from(2u64) * &p + BigUint::from(1u64);
 
-        // CHUNK_SIZE = 4 → max value = 2^4 = 16
+        // CHUNK_SIZE = 4 => max value = 2^4 = 16
         // Split hash_uint = 2p + 1 into base-16 digits (little endian)
         //
         // Example:

--- a/src/symmetric/message_hash/poseidon.rs
+++ b/src/symmetric/message_hash/poseidon.rs
@@ -57,7 +57,7 @@ fn decode_to_chunks<const NUM_CHUNKS: usize, const CHUNK_SIZE: usize, const HASH
     // Combine field elements into one big integer (little-endian base-p)
     let p = BigUint::from(FqConfig::MODULUS);
     let mut acc = BigUint::ZERO;
-    for fe in field_elements.iter().rev() {
+    for fe in field_elements.iter() {
         acc = &acc * &p + BigUint::from(fe.into_bigint());
     }
 


### PR DESCRIPTION
Same philosophy as https://github.com/b-wagn/hash-sig/pull/17

With the following micro benchmark:
```rust
/// Generate a random input of `HASH_LEN_FE` field elements
fn generate_random_input<const HASH_LEN_FE: usize>() -> [F; HASH_LEN_FE] {
    let mut rng = rand::thread_rng();
    std::array::from_fn(|_| F::rand(&mut rng))
}

/// Benchmark function
fn benchmark_decode_to_chunks(c: &mut Criterion) {
    const NUM_CHUNKS: usize = 256;
    const CHUNK_SIZE: usize = 8;
    const HASH_LEN_FE: usize = 32;

    let input = generate_random_input::<HASH_LEN_FE>();

    c.bench_function("decode_to_chunks_256x8_from_32fe", |b| {
        b.iter(|| {
            let result = decode_to_chunks::<NUM_CHUNKS, CHUNK_SIZE, HASH_LEN_FE>(black_box(&input));
            black_box(result);
        })

    });
}

criterion_group!(benches, benchmark_decode_to_chunks);
criterion_main!(benches);
```

I obtain about 12% speedup compared to the original implementation.