### PR TITLE
sign: small touchup

### DIFF
--- a/src/signature/generalized_xmss.rs
+++ b/src/signature/generalized_xmss.rs
@@ -236,7 +236,7 @@ where
             "Encoding is broken: returned too many or too few chunks."
         );
         let mut chain_ends = Vec::with_capacity(num_chains);
-        for (chain_index, xi) in x.iter().enumerate().take(num_chains) {
+        for (chain_index, xi) in x.iter().enumerate() {
             // If the signer has already walked x[i] steps, then we need
             // to walk chain_length - 1 - x[i] steps to reach the end of the chain
             let steps = chain_length - 1 - xi;

--- a/src/signature/generalized_xmss.rs
+++ b/src/signature/generalized_xmss.rs
@@ -188,7 +188,7 @@ where
             "Encoding is broken: returned too many or too few chunks."
         );
         let mut hashes = Vec::with_capacity(num_chains);
-        for (chain_index, xi) in x.iter().enumerate().take(num_chains) {
+        for (chain_index, xi) in x.iter().enumerate() {
             // get back the start of the chain from the PRF
             let start = PRF::apply(&sk.prf_key, epoch, chain_index as u64).into();
             // now walk the chain for a number of steps determined by x


### PR DESCRIPTION
Here I think that we can remove the `take(num_chains)` because it duplicates the check that is done a few lines above and which validates precisely

```rust
let num_chains = IE::NUM_CHUNKS;
assert!(
    x.len() == num_chains,
    "Encoding is broken: returned too many or too few chunks."
);
```