### PR TITLE
Refactor CHUNK_SIZE to BASE

### DIFF
--- a/src/inc_encoding.rs
+++ b/src/inc_encoding.rs
@@ -7,9 +7,11 @@ pub type EncodingError = ();
 
 /// Trait to model incomparable encoding schemes.
 /// These schemes allow to encode a message into a codeword.
-/// A codeword consists of a number of chunks, and each chunk has
-/// the same bit-length. For ease of use, we require chunks to be
-/// returned already as integers from 0 to 2^chunk_size - 1.
+///
+/// A codeword is vector of a fixed dimension containing
+/// integer elements between 0 and BASE - 1.
+/// We require BASE to be at most 1 << 16 to ensure that
+/// the entries fit into u16.
 ///
 /// The main feature of these encodings is that no two distinct
 /// codewords are "comparable", i.e., for no two codewords
@@ -19,15 +21,16 @@ pub trait IncomparableEncoding {
     type Parameter;
     type Randomness;
 
-    /// number of chunks of a codeword
-    const NUM_CHUNKS: usize;
+    /// number of entries in a codeword
+    const DIMENSION: usize;
 
     /// how often one should try at most
     /// to resample randomness before giving up.
     const MAX_TRIES: usize;
 
-    /// number of bits per chunks.
-    const CHUNK_SIZE: usize;
+    /// base of the code, i.e., codeword entries
+    /// are between 0 and BASE - 1
+    const BASE: usize;
 
     /// Samples a randomness to be used for the encoding.
     fn rand<R: Rng>(rng: &mut R) -> Self::Randomness;

--- a/src/inc_encoding.rs
+++ b/src/inc_encoding.rs
@@ -8,7 +8,7 @@ pub type EncodingError = ();
 /// Trait to model incomparable encoding schemes.
 /// These schemes allow to encode a message into a codeword.
 ///
-/// A codeword is vector of a fixed dimension containing
+/// A codeword is a vector of a fixed dimension containing
 /// integer elements between 0 and BASE - 1.
 /// We require BASE to be at most 1 << 16 to ensure that
 /// the entries fit into u16.

--- a/src/inc_encoding.rs
+++ b/src/inc_encoding.rs
@@ -10,7 +10,7 @@ pub type EncodingError = ();
 ///
 /// A codeword is a vector of a fixed dimension containing
 /// integer elements between 0 and BASE - 1.
-/// We require BASE to be at most 1 << 16 to ensure that
+/// **WARNING**: We require BASE to be at most 1 << 16 to ensure that
 /// the entries fit into u16.
 ///
 /// The main feature of these encodings is that no two distinct

--- a/src/inc_encoding/basic_winternitz.rs
+++ b/src/inc_encoding/basic_winternitz.rs
@@ -32,7 +32,6 @@ impl<MH: MessageHash, const CHUNK_SIZE: usize, const NUM_CHUNKS_CHECKSUM: usize>
     WinternitzEncoding<MH, CHUNK_SIZE, NUM_CHUNKS_CHECKSUM>
 {
     const NUM_CHUNKS_MESSAGE: usize = MH::DIMENSION;
-    const BASE: usize = 1 << CHUNK_SIZE;
     const NUM_CHUNKS: usize = Self::NUM_CHUNKS_MESSAGE + NUM_CHUNKS_CHECKSUM;
 }
 
@@ -47,7 +46,7 @@ impl<MH: MessageHash, const CHUNK_SIZE: usize, const NUM_CHUNKS_CHECKSUM: usize>
 
     const MAX_TRIES: usize = 1;
 
-    const BASE: usize = Self::BASE;
+    const BASE: usize = MH::BASE;
 
     fn rand<R: rand::Rng>(rng: &mut R) -> Self::Randomness {
         MH::rand(rng)

--- a/src/inc_encoding/basic_winternitz.rs
+++ b/src/inc_encoding/basic_winternitz.rs
@@ -8,30 +8,36 @@ use super::IncomparableEncoding;
 /// Incomparable Encoding Scheme based on the basic
 /// Winternitz scheme, implemented from a given message hash.
 ///
+/// Note: this supports chunk sizes 1,2,4, and 8, and the
+/// base of the message hash must be 2 ** CHUNK_SIZE
 ///
 /// Unfortunately, Rust cannot deal with logarithms and ceils in constants.
 /// Therefore, the user needs to supply NUM_CHUNKS_CHECKSUM. This value can
 /// be computed before compilation with the following steps:
 /// ```ignore
 ///     base = 2 ** MH::CHUNK_SIZE
-///     num_chunks_message = MH::NUM_CHUNKS
+///     num_chunks_message = MH::DIMENSION
 ///     max_checksum = num_chunks_message * (base - 1)
 ///     num_chunks_checksum = 1 + math.floor(math.log(max_checksum, base))
 /// ```
-pub struct WinternitzEncoding<MH: MessageHash, const NUM_CHUNKS_CHECKSUM: usize> {
+pub struct WinternitzEncoding<
+    MH: MessageHash,
+    const CHUNK_SIZE: usize,
+    const NUM_CHUNKS_CHECKSUM: usize,
+> {
     _marker_mh: std::marker::PhantomData<MH>,
 }
 
-impl<MH: MessageHash, const NUM_CHUNKS_CHECKSUM: usize>
-    WinternitzEncoding<MH, NUM_CHUNKS_CHECKSUM>
+impl<MH: MessageHash, const CHUNK_SIZE: usize, const NUM_CHUNKS_CHECKSUM: usize>
+    WinternitzEncoding<MH, CHUNK_SIZE, NUM_CHUNKS_CHECKSUM>
 {
     const NUM_CHUNKS_MESSAGE: usize = MH::DIMENSION;
-    const BASE: usize = 1 << MH::CHUNK_SIZE;
+    const BASE: usize = 1 << CHUNK_SIZE;
     const NUM_CHUNKS: usize = Self::NUM_CHUNKS_MESSAGE + NUM_CHUNKS_CHECKSUM;
 }
 
-impl<MH: MessageHash, const NUM_CHUNKS_CHECKSUM: usize> IncomparableEncoding
-    for WinternitzEncoding<MH, NUM_CHUNKS_CHECKSUM>
+impl<MH: MessageHash, const CHUNK_SIZE: usize, const NUM_CHUNKS_CHECKSUM: usize>
+    IncomparableEncoding for WinternitzEncoding<MH, CHUNK_SIZE, NUM_CHUNKS_CHECKSUM>
 {
     type Parameter = MH::Parameter;
 
@@ -64,7 +70,7 @@ impl<MH: MessageHash, const NUM_CHUNKS_CHECKSUM: usize> IncomparableEncoding
 
         // we split the checksum into chunks, in little-endian
         let checksum_bytes = checksum.to_le_bytes();
-        let chunks_checksum = bytes_to_chunks(&checksum_bytes, MH::CHUNK_SIZE);
+        let chunks_checksum = bytes_to_chunks(&checksum_bytes, CHUNK_SIZE);
 
         // Assemble the resulting vector
         // we take all message chunks, followed by the checksum chunks.
@@ -81,17 +87,21 @@ impl<MH: MessageHash, const NUM_CHUNKS_CHECKSUM: usize> IncomparableEncoding
     fn internal_consistency_check() {
         // chunk size must be 1, 2, 4, or 8
         assert!(
-            MH::CHUNK_SIZE > 0 && MH::CHUNK_SIZE <= 8 && 8 % MH::CHUNK_SIZE == 0,
+            CHUNK_SIZE > 0 && CHUNK_SIZE <= 8 && 8 % CHUNK_SIZE == 0,
             "Winternitz Encoding: Chunk Size must be 1, 2, 4, or 8"
         );
 
         // base must not be too large
         assert!(
-            MH::CHUNK_SIZE <= 16,
+            CHUNK_SIZE <= 16,
             "Winternitz Encoding: Base must be at most 2^16"
         );
 
-        // chunk size and base must be consistent
+        // chunk size and base of MH must be consistent
+        assert!(
+            MH::BASE == Self::BASE && MH::BASE == 1 << CHUNK_SIZE,
+            "Winternitz Encoding: Base and chunk size not consistent with message hash"
+        );
 
         // also check internal consistency of message hash
         MH::internal_consistency_check();

--- a/src/inc_encoding/basic_winternitz.rs
+++ b/src/inc_encoding/basic_winternitz.rs
@@ -87,7 +87,7 @@ impl<MH: MessageHash, const CHUNK_SIZE: usize, const NUM_CHUNKS_CHECKSUM: usize>
     fn internal_consistency_check() {
         // chunk size must be 1, 2, 4, or 8
         assert!(
-            CHUNK_SIZE > 0 && CHUNK_SIZE <= 8 && 8 % CHUNK_SIZE == 0,
+            [1, 2, 4, 8].contains(&CHUNK_SIZE),
             "Winternitz Encoding: Chunk Size must be 1, 2, 4, or 8"
         );
 

--- a/src/inc_encoding/target_sum.rs
+++ b/src/inc_encoding/target_sum.rs
@@ -19,7 +19,7 @@ pub struct TargetSumEncoding<MH: MessageHash, const TARGET_SUM: usize> {
 }
 
 impl<MH: MessageHash, const TARGET_SUM: usize> TargetSumEncoding<MH, TARGET_SUM> {
-    const NUM_CHUNKS: usize = MH::NUM_CHUNKS;
+    const NUM_CHUNKS: usize = MH::DIMENSION;
     const TARGET_SUM: usize = TARGET_SUM;
 }
 
@@ -30,14 +30,14 @@ impl<MH: MessageHash, const TARGET_SUM: usize> IncomparableEncoding
 
     type Randomness = MH::Randomness;
 
-    const NUM_CHUNKS: usize = Self::NUM_CHUNKS;
+    const DIMENSION: usize = Self::NUM_CHUNKS;
 
     /// we did one experiment with random message hashes.
     /// In production, this should be estimated via more
     /// extensive experiments with concrete hash functions.
     const MAX_TRIES: usize = 100000;
 
-    const CHUNK_SIZE: usize = MH::CHUNK_SIZE;
+    const BASE: usize = 1 << MH::CHUNK_SIZE;
 
     fn rand<R: rand::Rng>(rng: &mut R) -> Self::Randomness {
         MH::rand(rng)
@@ -70,6 +70,13 @@ impl<MH: MessageHash, const TARGET_SUM: usize> IncomparableEncoding
             MH::CHUNK_SIZE > 0 && MH::CHUNK_SIZE <= 8 && 8 % MH::CHUNK_SIZE == 0,
             "Target Sum Encoding: Chunk Size must be 1, 2, 4, or 8"
         );
+
+        // base must not be too large
+        assert!(
+            MH::CHUNK_SIZE <= 16,
+            "Target Sum Encoding: Base must be at most 2^16"
+        );
+
         // also check internal consistency of message hash
         MH::internal_consistency_check();
     }

--- a/src/inc_encoding/target_sum.rs
+++ b/src/inc_encoding/target_sum.rs
@@ -18,11 +18,6 @@ pub struct TargetSumEncoding<MH: MessageHash, const TARGET_SUM: usize> {
     _marker_mh: std::marker::PhantomData<MH>,
 }
 
-impl<MH: MessageHash, const TARGET_SUM: usize> TargetSumEncoding<MH, TARGET_SUM> {
-    const NUM_CHUNKS: usize = MH::DIMENSION;
-    const TARGET_SUM: usize = TARGET_SUM;
-}
-
 impl<MH: MessageHash, const TARGET_SUM: usize> IncomparableEncoding
     for TargetSumEncoding<MH, TARGET_SUM>
 {
@@ -30,7 +25,7 @@ impl<MH: MessageHash, const TARGET_SUM: usize> IncomparableEncoding
 
     type Randomness = MH::Randomness;
 
-    const DIMENSION: usize = Self::NUM_CHUNKS;
+    const DIMENSION: usize = MH::DIMENSION;
 
     /// we did one experiment with random message hashes.
     /// In production, this should be estimated via more
@@ -55,7 +50,7 @@ impl<MH: MessageHash, const TARGET_SUM: usize> IncomparableEncoding
 
         let sum: u32 = chunks_u32.iter().sum();
         // only output something if the chunks sum to the target sum
-        if sum as usize == Self::TARGET_SUM {
+        if sum as usize == TARGET_SUM {
             Ok(chunks)
         } else {
             Err(())

--- a/src/inc_encoding/target_sum.rs
+++ b/src/inc_encoding/target_sum.rs
@@ -46,9 +46,7 @@ impl<MH: MessageHash, const TARGET_SUM: usize> IncomparableEncoding
     ) -> Result<Vec<u16>, super::EncodingError> {
         // apply the message hash first to get chunks
         let chunks = MH::apply(parameter, epoch, randomness, message);
-        let chunks_u32: Vec<u32> = chunks.iter().map(|&x| x as u32).collect();
-
-        let sum: u32 = chunks_u32.iter().sum();
+        let sum: u32 = chunks.iter().map(|&x| x as u32).sum();
         // only output something if the chunks sum to the target sum
         if sum as usize == TARGET_SUM {
             Ok(chunks)

--- a/src/signature/generalized_xmss.rs
+++ b/src/signature/generalized_xmss.rs
@@ -304,9 +304,9 @@ mod tests {
         type PRF = ShaPRF<24>;
         type TH = ShaTweak192192;
         type MH = ShaMessageHash192x3;
-        const _CHUNK_SIZE: usize = 2;
+        const CHUNK_SIZE: usize = 4;
         const NUM_CHUNKS_CHECKSUM: usize = 3;
-        type IE = WinternitzEncoding<MH, NUM_CHUNKS_CHECKSUM>;
+        type IE = WinternitzEncoding<MH, CHUNK_SIZE, NUM_CHUNKS_CHECKSUM>;
         const LOG_LIFETIME: usize = 9;
         type SIG = GeneralizedXMSSSignatureScheme<PRF, IE, TH, LOG_LIFETIME>;
 
@@ -324,9 +324,10 @@ mod tests {
         type PRF = ShakePRFtoF<7>;
         type TH = PoseidonTweakW1L5;
         type MH = PoseidonMessageHashW1;
-        const _CHUNK_SIZE: usize = 1;
+        const CHUNK_SIZE: usize = 1;
+        const _BASE: usize = 2;
         const NUM_CHUNKS_CHECKSUM: usize = 8;
-        type IE = WinternitzEncoding<MH, NUM_CHUNKS_CHECKSUM>;
+        type IE = WinternitzEncoding<MH, CHUNK_SIZE, NUM_CHUNKS_CHECKSUM>;
         const LOG_LIFETIME: usize = 5;
         type SIG = GeneralizedXMSSSignatureScheme<PRF, IE, TH, LOG_LIFETIME>;
 
@@ -344,9 +345,9 @@ mod tests {
         type PRF = ShaPRF<24>;
         type TH = ShaTweak192192;
         type MH = ShaMessageHash192x3;
-        const CHUNK_SIZE: usize = MH::CHUNK_SIZE;
+        const BASE: usize = MH::BASE;
         const NUM_CHUNKS: usize = MH::DIMENSION;
-        const MAX_CHUNK_VALUE: usize = (1 << CHUNK_SIZE) - 1;
+        const MAX_CHUNK_VALUE: usize = BASE - 1;
         const EXPECTED_SUM: usize = NUM_CHUNKS * MAX_CHUNK_VALUE / 2;
         type IE = TargetSumEncoding<MH, EXPECTED_SUM>;
         const LOG_LIFETIME: usize = 8;
@@ -362,14 +363,14 @@ mod tests {
     }
 
     #[test]
-    pub fn test_target_sum_winternitz_poseidon() {
+    pub fn test_target_sum_poseidon() {
         // Note: do not use these parameters, they are just for testing
         type PRF = ShakePRFtoF<7>;
         type TH = PoseidonTweakW1L5;
         type MH = PoseidonMessageHashW1;
-        const CHUNK_SIZE: usize = MH::CHUNK_SIZE;
+        const BASE: usize = MH::BASE;
         const NUM_CHUNKS: usize = MH::DIMENSION;
-        const MAX_CHUNK_VALUE: usize = (1 << CHUNK_SIZE) - 1;
+        const MAX_CHUNK_VALUE: usize = BASE - 1;
         const EXPECTED_SUM: usize = NUM_CHUNKS * MAX_CHUNK_VALUE / 2;
         type IE = TargetSumEncoding<MH, EXPECTED_SUM>;
         const LOG_LIFETIME: usize = 5;

--- a/src/signature/generalized_xmss.rs
+++ b/src/signature/generalized_xmss.rs
@@ -97,8 +97,8 @@ where
         // chain starting at the secret key element.
         // The public key for that epoch is then the hash of all chain ends.
 
-        let num_chains = IE::NUM_CHUNKS;
-        let chain_length = 1 << IE::CHUNK_SIZE;
+        let num_chains = IE::DIMENSION;
+        let chain_length = IE::BASE;
 
         // parallelize the chain ends hash computation for each epoch
         let chain_ends_hashes = (0..Self::LIFETIME)
@@ -185,7 +185,7 @@ where
 
         // we will include rho in the signature, and
         // we use x to determine how far the signer walks in the chains
-        let num_chains = IE::NUM_CHUNKS;
+        let num_chains = IE::DIMENSION;
         assert!(
             x.len() == num_chains,
             "Encoding is broken: returned too many or too few chunks."
@@ -232,8 +232,8 @@ where
 
         // now, we recompute the epoch's one-time public key
         // from the hashes by walking hash chains.
-        let chain_length = 1 << IE::CHUNK_SIZE;
-        let num_chains = IE::NUM_CHUNKS;
+        let chain_length = IE::BASE;
+        let num_chains = IE::DIMENSION;
         assert!(
             x.len() == num_chains,
             "Encoding is broken: returned too many or too few chunks."
@@ -242,7 +242,7 @@ where
         for (chain_index, xi) in x.iter().enumerate() {
             // If the signer has already walked x[i] steps, then we need
             // to walk chain_length - 1 - x[i] steps to reach the end of the chain
-            let steps = chain_length - 1 - xi;
+            let steps = (chain_length - 1) as u16 - xi;
             let start_pos_in_chain = *xi;
             let start = &sig.hashes[chain_index];
             let end = chain::<TH>(
@@ -345,7 +345,7 @@ mod tests {
         type TH = ShaTweak192192;
         type MH = ShaMessageHash192x3;
         const CHUNK_SIZE: usize = MH::CHUNK_SIZE;
-        const NUM_CHUNKS: usize = MH::NUM_CHUNKS;
+        const NUM_CHUNKS: usize = MH::DIMENSION;
         const MAX_CHUNK_VALUE: usize = (1 << CHUNK_SIZE) - 1;
         const EXPECTED_SUM: usize = NUM_CHUNKS * MAX_CHUNK_VALUE / 2;
         type IE = TargetSumEncoding<MH, EXPECTED_SUM>;
@@ -368,7 +368,7 @@ mod tests {
         type TH = PoseidonTweakW1L5;
         type MH = PoseidonMessageHashW1;
         const CHUNK_SIZE: usize = MH::CHUNK_SIZE;
-        const NUM_CHUNKS: usize = MH::NUM_CHUNKS;
+        const NUM_CHUNKS: usize = MH::DIMENSION;
         const MAX_CHUNK_VALUE: usize = (1 << CHUNK_SIZE) - 1;
         const EXPECTED_SUM: usize = NUM_CHUNKS * MAX_CHUNK_VALUE / 2;
         type IE = TargetSumEncoding<MH, EXPECTED_SUM>;

--- a/src/signature/generalized_xmss/instantiations_poseidon.rs
+++ b/src/signature/generalized_xmss/instantiations_poseidon.rs
@@ -21,22 +21,20 @@ pub mod lifetime_2_to_the_18 {
         const CAPACITY: usize = 9;
 
         const CHUNK_SIZE_W1: usize = 1;
+        const BASE_W1: usize = 2;
         const NUM_CHUNKS_W1: usize = 155;
         const NUM_CHUNKS_CHECKSUM_W1: usize = 8;
-        const CEIL_LOG_NUM_CHAINS_W1: usize = 8;
+        const _CEIL_LOG_NUM_CHAINS_W1: usize = 8;
         type MHw1 = PoseidonMessageHash<
             PARAMETER_LEN,
             RAND_LEN,
             MSG_HASH_LEN_FE,
             NUM_CHUNKS_W1,
-            CHUNK_SIZE_W1,
+            BASE_W1,
             TWEAK_LEN_FE,
             MSG_LEN_FE,
         >;
         type THw1 = PoseidonTweakHash<
-            LOG_LIFETIME,
-            CEIL_LOG_NUM_CHAINS_W1,
-            CHUNK_SIZE_W1,
             PARAMETER_LEN,
             HASH_LEN_FE,
             TWEAK_LEN_FE,
@@ -44,28 +42,26 @@ pub mod lifetime_2_to_the_18 {
             NUM_CHUNKS_W1,
         >;
         type PRFw1 = ShakePRFtoF<HASH_LEN_FE>;
-        type IEw1 = WinternitzEncoding<MHw1, NUM_CHUNKS_CHECKSUM_W1>;
+        type IEw1 = WinternitzEncoding<MHw1, CHUNK_SIZE_W1, NUM_CHUNKS_CHECKSUM_W1>;
         /// Instantiation with Lifetime 2^18, Winternitz encoding, chunk size w = 1
         pub type SIGWinternitzLifetime18W1 =
             GeneralizedXMSSSignatureScheme<PRFw1, IEw1, THw1, LOG_LIFETIME>;
 
         const CHUNK_SIZE_W2: usize = 2;
+        const BASE_W2: usize = 4;
         const NUM_CHUNKS_W2: usize = 78;
         const NUM_CHUNKS_CHECKSUM_W2: usize = 4;
-        const CEIL_LOG_NUM_CHAINS_W2: usize = 7;
+        const _CEIL_LOG_NUM_CHAINS_W2: usize = 7;
         type MHw2 = PoseidonMessageHash<
             PARAMETER_LEN,
             RAND_LEN,
             MSG_HASH_LEN_FE,
             NUM_CHUNKS_W2,
-            CHUNK_SIZE_W2,
+            BASE_W2,
             TWEAK_LEN_FE,
             MSG_LEN_FE,
         >;
         type THw2 = PoseidonTweakHash<
-            LOG_LIFETIME,
-            CEIL_LOG_NUM_CHAINS_W2,
-            CHUNK_SIZE_W2,
             PARAMETER_LEN,
             HASH_LEN_FE,
             TWEAK_LEN_FE,
@@ -73,28 +69,26 @@ pub mod lifetime_2_to_the_18 {
             NUM_CHUNKS_W2,
         >;
         type PRFw2 = ShakePRFtoF<HASH_LEN_FE>;
-        type IEw2 = WinternitzEncoding<MHw2, NUM_CHUNKS_CHECKSUM_W2>;
+        type IEw2 = WinternitzEncoding<MHw2, CHUNK_SIZE_W2, NUM_CHUNKS_CHECKSUM_W2>;
         /// Instantiation with Lifetime 2^18, Winternitz encoding, chunk size w = 2
         pub type SIGWinternitzLifetime18W2 =
             GeneralizedXMSSSignatureScheme<PRFw2, IEw2, THw2, LOG_LIFETIME>;
 
         const CHUNK_SIZE_W4: usize = 4;
+        const BASE_W4: usize = 16;
         const NUM_CHUNKS_W4: usize = 39;
         const NUM_CHUNKS_CHECKSUM_W4: usize = 3;
-        const CEIL_LOG_NUM_CHAINS_W4: usize = 6;
+        const _CEIL_LOG_NUM_CHAINS_W4: usize = 6;
         type MHw4 = PoseidonMessageHash<
             PARAMETER_LEN,
             RAND_LEN,
             MSG_HASH_LEN_FE,
             NUM_CHUNKS_W4,
-            CHUNK_SIZE_W4,
+            BASE_W4,
             TWEAK_LEN_FE,
             MSG_LEN_FE,
         >;
         type THw4 = PoseidonTweakHash<
-            LOG_LIFETIME,
-            CEIL_LOG_NUM_CHAINS_W4,
-            CHUNK_SIZE_W4,
             PARAMETER_LEN,
             HASH_LEN_FE,
             TWEAK_LEN_FE,
@@ -102,28 +96,26 @@ pub mod lifetime_2_to_the_18 {
             NUM_CHUNKS_W4,
         >;
         type PRFw4 = ShakePRFtoF<HASH_LEN_FE>;
-        type IEw4 = WinternitzEncoding<MHw4, NUM_CHUNKS_CHECKSUM_W4>;
+        type IEw4 = WinternitzEncoding<MHw4, CHUNK_SIZE_W4, NUM_CHUNKS_CHECKSUM_W4>;
         /// Instantiation with Lifetime 2^18, Winternitz encoding, chunk size w = 4
         pub type SIGWinternitzLifetime18W4 =
             GeneralizedXMSSSignatureScheme<PRFw4, IEw4, THw4, LOG_LIFETIME>;
 
         const CHUNK_SIZE_W8: usize = 8;
+        const BASE_W8: usize = 256;
         const NUM_CHUNKS_W8: usize = 20;
         const NUM_CHUNKS_CHECKSUM_W8: usize = 2;
-        const CEIL_LOG_NUM_CHAINS_W8: usize = 5;
+        const _CEIL_LOG_NUM_CHAINS_W8: usize = 5;
         type MHw8 = PoseidonMessageHash<
             PARAMETER_LEN,
             RAND_LEN,
             MSG_HASH_LEN_FE,
             NUM_CHUNKS_W8,
-            CHUNK_SIZE_W8,
+            BASE_W8,
             TWEAK_LEN_FE,
             MSG_LEN_FE,
         >;
         type THw8 = PoseidonTweakHash<
-            LOG_LIFETIME,
-            CEIL_LOG_NUM_CHAINS_W8,
-            CHUNK_SIZE_W8,
             PARAMETER_LEN,
             HASH_LEN_FE,
             TWEAK_LEN_FE,
@@ -131,7 +123,7 @@ pub mod lifetime_2_to_the_18 {
             NUM_CHUNKS_W8,
         >;
         type PRFw8 = ShakePRFtoF<HASH_LEN_FE>;
-        type IEw8 = WinternitzEncoding<MHw8, NUM_CHUNKS_CHECKSUM_W8>;
+        type IEw8 = WinternitzEncoding<MHw8, CHUNK_SIZE_W8, NUM_CHUNKS_CHECKSUM_W8>;
         /// Instantiation with Lifetime 2^18, Winternitz encoding, chunk size w = 8
         pub type SIGWinternitzLifetime18W8 =
             GeneralizedXMSSSignatureScheme<PRFw8, IEw8, THw8, LOG_LIFETIME>;
@@ -207,22 +199,20 @@ pub mod lifetime_2_to_the_18 {
         const RAND_LEN: usize = 6;
         const CAPACITY: usize = 9;
 
-        const CHUNK_SIZE_W1: usize = 1;
+        const _CHUNK_SIZE_W1: usize = 1;
+        const BASE_W1: usize = 2;
         const NUM_CHUNKS_W1: usize = 155;
-        const CEIL_LOG_NUM_CHAINS_W1: usize = 8;
+        const _CEIL_LOG_NUM_CHAINS_W1: usize = 8;
         type MHw1 = PoseidonMessageHash<
             PARAMETER_LEN,
             RAND_LEN,
             MSG_HASH_LEN_FE,
             NUM_CHUNKS_W1,
-            CHUNK_SIZE_W1,
+            BASE_W1,
             TWEAK_LEN_FE,
             MSG_LEN_FE,
         >;
         type THw1 = PoseidonTweakHash<
-            LOG_LIFETIME,
-            CEIL_LOG_NUM_CHAINS_W1,
-            CHUNK_SIZE_W1,
             PARAMETER_LEN,
             HASH_LEN_FE,
             TWEAK_LEN_FE,
@@ -240,22 +230,20 @@ pub mod lifetime_2_to_the_18 {
         pub type SIGTargetSumLifetime18W1Off10 =
             GeneralizedXMSSSignatureScheme<PRFw1, IEw1<86>, THw1, LOG_LIFETIME>;
 
-        const CHUNK_SIZE_W2: usize = 2;
+        const _CHUNK_SIZE_W2: usize = 2;
+        const BASE_W2: usize = 4;
         const NUM_CHUNKS_W2: usize = 78;
-        const CEIL_LOG_NUM_CHAINS_W2: usize = 7;
+        const _CEIL_LOG_NUM_CHAINS_W2: usize = 7;
         type MHw2 = PoseidonMessageHash<
             PARAMETER_LEN,
             RAND_LEN,
             MSG_HASH_LEN_FE,
             NUM_CHUNKS_W2,
-            CHUNK_SIZE_W2,
+            BASE_W2,
             TWEAK_LEN_FE,
             MSG_LEN_FE,
         >;
         type THw2 = PoseidonTweakHash<
-            LOG_LIFETIME,
-            CEIL_LOG_NUM_CHAINS_W2,
-            CHUNK_SIZE_W2,
             PARAMETER_LEN,
             HASH_LEN_FE,
             TWEAK_LEN_FE,
@@ -273,22 +261,20 @@ pub mod lifetime_2_to_the_18 {
         pub type SIGTargetSumLifetime18W2Off10 =
             GeneralizedXMSSSignatureScheme<PRFw2, IEw2<129>, THw2, LOG_LIFETIME>;
 
-        const CHUNK_SIZE_W4: usize = 4;
+        const _CHUNK_SIZE_W4: usize = 4;
+        const BASE_W4: usize = 16;
         const NUM_CHUNKS_W4: usize = 39;
-        const CEIL_LOG_NUM_CHAINS_W4: usize = 6;
+        const _CEIL_LOG_NUM_CHAINS_W4: usize = 6;
         type MHw4 = PoseidonMessageHash<
             PARAMETER_LEN,
             RAND_LEN,
             MSG_HASH_LEN_FE,
             NUM_CHUNKS_W4,
-            CHUNK_SIZE_W4,
+            BASE_W4,
             TWEAK_LEN_FE,
             MSG_LEN_FE,
         >;
         type THw4 = PoseidonTweakHash<
-            LOG_LIFETIME,
-            CEIL_LOG_NUM_CHAINS_W4,
-            CHUNK_SIZE_W4,
             PARAMETER_LEN,
             HASH_LEN_FE,
             TWEAK_LEN_FE,
@@ -306,22 +292,20 @@ pub mod lifetime_2_to_the_18 {
         pub type SIGTargetSumLifetime18W4Off10 =
             GeneralizedXMSSSignatureScheme<PRFw4, IEw4<322>, THw4, LOG_LIFETIME>;
 
-        const CHUNK_SIZE_W8: usize = 8;
+        const _CHUNK_SIZE_W8: usize = 8;
+        const BASE_W8: usize = 256;
         const NUM_CHUNKS_W8: usize = 20;
-        const CEIL_LOG_NUM_CHAINS_W8: usize = 5;
+        const _CEIL_LOG_NUM_CHAINS_W8: usize = 5;
         type MHw8 = PoseidonMessageHash<
             PARAMETER_LEN,
             RAND_LEN,
             MSG_HASH_LEN_FE,
             NUM_CHUNKS_W8,
-            CHUNK_SIZE_W8,
+            BASE_W8,
             TWEAK_LEN_FE,
             MSG_LEN_FE,
         >;
         type THw8 = PoseidonTweakHash<
-            LOG_LIFETIME,
-            CEIL_LOG_NUM_CHAINS_W8,
-            CHUNK_SIZE_W8,
             PARAMETER_LEN,
             HASH_LEN_FE,
             TWEAK_LEN_FE,
@@ -429,22 +413,20 @@ pub mod lifetime_2_to_the_20 {
         const CAPACITY: usize = 9;
 
         const CHUNK_SIZE_W1: usize = 1;
+        const BASE_W1: usize = 2;
         const NUM_CHUNKS_W1: usize = 155;
         const NUM_CHUNKS_CHECKSUM_W1: usize = 8;
-        const CEIL_LOG_NUM_CHAINS_W1: usize = 8;
+        const _CEIL_LOG_NUM_CHAINS_W1: usize = 8;
         type MHw1 = PoseidonMessageHash<
             PARAMETER_LEN,
             RAND_LEN,
             MSG_HASH_LEN_FE,
             NUM_CHUNKS_W1,
-            CHUNK_SIZE_W1,
+            BASE_W1,
             TWEAK_LEN_FE,
             MSG_LEN_FE,
         >;
         type THw1 = PoseidonTweakHash<
-            LOG_LIFETIME,
-            CEIL_LOG_NUM_CHAINS_W1,
-            CHUNK_SIZE_W1,
             PARAMETER_LEN,
             HASH_LEN_FE,
             TWEAK_LEN_FE,
@@ -452,28 +434,26 @@ pub mod lifetime_2_to_the_20 {
             NUM_CHUNKS_W1,
         >;
         type PRFw1 = ShakePRFtoF<HASH_LEN_FE>;
-        type IEw1 = WinternitzEncoding<MHw1, NUM_CHUNKS_CHECKSUM_W1>;
+        type IEw1 = WinternitzEncoding<MHw1, CHUNK_SIZE_W1, NUM_CHUNKS_CHECKSUM_W1>;
         /// Instantiation with Lifetime 2^20, Winternitz encoding, chunk size w = 1
         pub type SIGWinternitzLifetime20W1 =
             GeneralizedXMSSSignatureScheme<PRFw1, IEw1, THw1, LOG_LIFETIME>;
 
         const CHUNK_SIZE_W2: usize = 2;
+        const BASE_W2: usize = 4;
         const NUM_CHUNKS_W2: usize = 78;
         const NUM_CHUNKS_CHECKSUM_W2: usize = 4;
-        const CEIL_LOG_NUM_CHAINS_W2: usize = 7;
+        const _CEIL_LOG_NUM_CHAINS_W2: usize = 7;
         type MHw2 = PoseidonMessageHash<
             PARAMETER_LEN,
             RAND_LEN,
             MSG_HASH_LEN_FE,
             NUM_CHUNKS_W2,
-            CHUNK_SIZE_W2,
+            BASE_W2,
             TWEAK_LEN_FE,
             MSG_LEN_FE,
         >;
         type THw2 = PoseidonTweakHash<
-            LOG_LIFETIME,
-            CEIL_LOG_NUM_CHAINS_W2,
-            CHUNK_SIZE_W2,
             PARAMETER_LEN,
             HASH_LEN_FE,
             TWEAK_LEN_FE,
@@ -481,28 +461,26 @@ pub mod lifetime_2_to_the_20 {
             NUM_CHUNKS_W2,
         >;
         type PRFw2 = ShakePRFtoF<HASH_LEN_FE>;
-        type IEw2 = WinternitzEncoding<MHw2, NUM_CHUNKS_CHECKSUM_W2>;
+        type IEw2 = WinternitzEncoding<MHw2, CHUNK_SIZE_W2, NUM_CHUNKS_CHECKSUM_W2>;
         /// Instantiation with Lifetime 2^20, Winternitz encoding, chunk size w = 2
         pub type SIGWinternitzLifetime20W2 =
             GeneralizedXMSSSignatureScheme<PRFw2, IEw2, THw2, LOG_LIFETIME>;
 
         const CHUNK_SIZE_W4: usize = 4;
+        const BASE_W4: usize = 16;
         const NUM_CHUNKS_W4: usize = 39;
         const NUM_CHUNKS_CHECKSUM_W4: usize = 3;
-        const CEIL_LOG_NUM_CHAINS_W4: usize = 6;
+        const _CEIL_LOG_NUM_CHAINS_W4: usize = 6;
         type MHw4 = PoseidonMessageHash<
             PARAMETER_LEN,
             RAND_LEN,
             MSG_HASH_LEN_FE,
             NUM_CHUNKS_W4,
-            CHUNK_SIZE_W4,
+            BASE_W4,
             TWEAK_LEN_FE,
             MSG_LEN_FE,
         >;
         type THw4 = PoseidonTweakHash<
-            LOG_LIFETIME,
-            CEIL_LOG_NUM_CHAINS_W4,
-            CHUNK_SIZE_W4,
             PARAMETER_LEN,
             HASH_LEN_FE,
             TWEAK_LEN_FE,
@@ -510,29 +488,27 @@ pub mod lifetime_2_to_the_20 {
             NUM_CHUNKS_W4,
         >;
         type PRFw4 = ShakePRFtoF<HASH_LEN_FE>;
-        type IEw4 = WinternitzEncoding<MHw4, NUM_CHUNKS_CHECKSUM_W4>;
+        type IEw4 = WinternitzEncoding<MHw4, CHUNK_SIZE_W4, NUM_CHUNKS_CHECKSUM_W4>;
         /// Instantiation with Lifetime 2^20, Winternitz encoding, chunk size w = 4
         pub type SIGWinternitzLifetime20W4 =
             GeneralizedXMSSSignatureScheme<PRFw4, IEw4, THw4, LOG_LIFETIME>;
 
         const HASH_LEN_FE_W8: usize = 8;
         const CHUNK_SIZE_W8: usize = 8;
+        const BASE_W8: usize = 256;
         const NUM_CHUNKS_W8: usize = 20;
         const NUM_CHUNKS_CHECKSUM_W8: usize = 2;
-        const CEIL_LOG_NUM_CHAINS_W8: usize = 5;
+        const _CEIL_LOG_NUM_CHAINS_W8: usize = 5;
         type MHw8 = PoseidonMessageHash<
             PARAMETER_LEN,
             RAND_LEN,
             MSG_HASH_LEN_FE,
             NUM_CHUNKS_W8,
-            CHUNK_SIZE_W8,
+            BASE_W8,
             TWEAK_LEN_FE,
             MSG_LEN_FE,
         >;
         type THw8 = PoseidonTweakHash<
-            LOG_LIFETIME,
-            CEIL_LOG_NUM_CHAINS_W8,
-            CHUNK_SIZE_W8,
             PARAMETER_LEN,
             HASH_LEN_FE_W8,
             TWEAK_LEN_FE,
@@ -540,7 +516,7 @@ pub mod lifetime_2_to_the_20 {
             NUM_CHUNKS_W8,
         >;
         type PRFw8 = ShakePRFtoF<HASH_LEN_FE_W8>;
-        type IEw8 = WinternitzEncoding<MHw8, NUM_CHUNKS_CHECKSUM_W8>;
+        type IEw8 = WinternitzEncoding<MHw8, CHUNK_SIZE_W8, NUM_CHUNKS_CHECKSUM_W8>;
         /// Instantiation with Lifetime 2^20, Winternitz encoding, chunk size w = 8
         pub type SIGWinternitzLifetime20W8 =
             GeneralizedXMSSSignatureScheme<PRFw8, IEw8, THw8, LOG_LIFETIME>;
@@ -616,22 +592,20 @@ pub mod lifetime_2_to_the_20 {
         const RAND_LEN: usize = 6;
         const CAPACITY: usize = 9;
 
-        const CHUNK_SIZE_W1: usize = 1;
+        const _CHUNK_SIZE_W1: usize = 1;
+        const BASE_W1: usize = 2;
         const NUM_CHUNKS_W1: usize = 155;
-        const CEIL_LOG_NUM_CHAINS_W1: usize = 8;
+        const _CEIL_LOG_NUM_CHAINS_W1: usize = 8;
         type MHw1 = PoseidonMessageHash<
             PARAMETER_LEN,
             RAND_LEN,
             MSG_HASH_LEN_FE,
             NUM_CHUNKS_W1,
-            CHUNK_SIZE_W1,
+            BASE_W1,
             TWEAK_LEN_FE,
             MSG_LEN_FE,
         >;
         type THw1 = PoseidonTweakHash<
-            LOG_LIFETIME,
-            CEIL_LOG_NUM_CHAINS_W1,
-            CHUNK_SIZE_W1,
             PARAMETER_LEN,
             HASH_LEN_FE,
             TWEAK_LEN_FE,
@@ -649,22 +623,20 @@ pub mod lifetime_2_to_the_20 {
         pub type SIGTargetSumLifetime20W1Off10 =
             GeneralizedXMSSSignatureScheme<PRFw1, IEw1<86>, THw1, LOG_LIFETIME>;
 
-        const CHUNK_SIZE_W2: usize = 2;
+        const _CHUNK_SIZE_W2: usize = 2;
+        const BASE_W2: usize = 4;
         const NUM_CHUNKS_W2: usize = 78;
-        const CEIL_LOG_NUM_CHAINS_W2: usize = 7;
+        const _CEIL_LOG_NUM_CHAINS_W2: usize = 7;
         type MHw2 = PoseidonMessageHash<
             PARAMETER_LEN,
             RAND_LEN,
             MSG_HASH_LEN_FE,
             NUM_CHUNKS_W2,
-            CHUNK_SIZE_W2,
+            BASE_W2,
             TWEAK_LEN_FE,
             MSG_LEN_FE,
         >;
         type THw2 = PoseidonTweakHash<
-            LOG_LIFETIME,
-            CEIL_LOG_NUM_CHAINS_W2,
-            CHUNK_SIZE_W2,
             PARAMETER_LEN,
             HASH_LEN_FE,
             TWEAK_LEN_FE,
@@ -682,22 +654,20 @@ pub mod lifetime_2_to_the_20 {
         pub type SIGTargetSumLifetime20W2Off10 =
             GeneralizedXMSSSignatureScheme<PRFw2, IEw2<129>, THw2, LOG_LIFETIME>;
 
-        const CHUNK_SIZE_W4: usize = 4;
+        const _CHUNK_SIZE_W4: usize = 4;
+        const BASE_W4: usize = 16;
         const NUM_CHUNKS_W4: usize = 39;
-        const CEIL_LOG_NUM_CHAINS_W4: usize = 6;
+        const _CEIL_LOG_NUM_CHAINS_W4: usize = 6;
         type MHw4 = PoseidonMessageHash<
             PARAMETER_LEN,
             RAND_LEN,
             MSG_HASH_LEN_FE,
             NUM_CHUNKS_W4,
-            CHUNK_SIZE_W4,
+            BASE_W4,
             TWEAK_LEN_FE,
             MSG_LEN_FE,
         >;
         type THw4 = PoseidonTweakHash<
-            LOG_LIFETIME,
-            CEIL_LOG_NUM_CHAINS_W4,
-            CHUNK_SIZE_W4,
             PARAMETER_LEN,
             HASH_LEN_FE,
             TWEAK_LEN_FE,
@@ -716,22 +686,20 @@ pub mod lifetime_2_to_the_20 {
             GeneralizedXMSSSignatureScheme<PRFw4, IEw4<322>, THw4, LOG_LIFETIME>;
 
         const HASH_LEN_FE_W8: usize = 8;
-        const CHUNK_SIZE_W8: usize = 8;
+        const _CHUNK_SIZE_W8: usize = 8;
+        const BASE_W8: usize = 256;
         const NUM_CHUNKS_W8: usize = 20;
-        const CEIL_LOG_NUM_CHAINS_W8: usize = 5;
+        const _CEIL_LOG_NUM_CHAINS_W8: usize = 5;
         type MHw8 = PoseidonMessageHash<
             PARAMETER_LEN,
             RAND_LEN,
             MSG_HASH_LEN_FE,
             NUM_CHUNKS_W8,
-            CHUNK_SIZE_W8,
+            BASE_W8,
             TWEAK_LEN_FE,
             MSG_LEN_FE,
         >;
         type THw8 = PoseidonTweakHash<
-            LOG_LIFETIME,
-            CEIL_LOG_NUM_CHAINS_W8,
-            CHUNK_SIZE_W8,
             PARAMETER_LEN,
             HASH_LEN_FE_W8,
             TWEAK_LEN_FE,

--- a/src/signature/generalized_xmss/instantiations_poseidon.rs
+++ b/src/signature/generalized_xmss/instantiations_poseidon.rs
@@ -34,13 +34,8 @@ pub mod lifetime_2_to_the_18 {
             TWEAK_LEN_FE,
             MSG_LEN_FE,
         >;
-        type THw1 = PoseidonTweakHash<
-            PARAMETER_LEN,
-            HASH_LEN_FE,
-            TWEAK_LEN_FE,
-            CAPACITY,
-            NUM_CHUNKS_W1,
-        >;
+        type THw1 =
+            PoseidonTweakHash<PARAMETER_LEN, HASH_LEN_FE, TWEAK_LEN_FE, CAPACITY, NUM_CHUNKS_W1>;
         type PRFw1 = ShakePRFtoF<HASH_LEN_FE>;
         type IEw1 = WinternitzEncoding<MHw1, CHUNK_SIZE_W1, NUM_CHUNKS_CHECKSUM_W1>;
         /// Instantiation with Lifetime 2^18, Winternitz encoding, chunk size w = 1
@@ -61,13 +56,8 @@ pub mod lifetime_2_to_the_18 {
             TWEAK_LEN_FE,
             MSG_LEN_FE,
         >;
-        type THw2 = PoseidonTweakHash<
-            PARAMETER_LEN,
-            HASH_LEN_FE,
-            TWEAK_LEN_FE,
-            CAPACITY,
-            NUM_CHUNKS_W2,
-        >;
+        type THw2 =
+            PoseidonTweakHash<PARAMETER_LEN, HASH_LEN_FE, TWEAK_LEN_FE, CAPACITY, NUM_CHUNKS_W2>;
         type PRFw2 = ShakePRFtoF<HASH_LEN_FE>;
         type IEw2 = WinternitzEncoding<MHw2, CHUNK_SIZE_W2, NUM_CHUNKS_CHECKSUM_W2>;
         /// Instantiation with Lifetime 2^18, Winternitz encoding, chunk size w = 2
@@ -88,13 +78,8 @@ pub mod lifetime_2_to_the_18 {
             TWEAK_LEN_FE,
             MSG_LEN_FE,
         >;
-        type THw4 = PoseidonTweakHash<
-            PARAMETER_LEN,
-            HASH_LEN_FE,
-            TWEAK_LEN_FE,
-            CAPACITY,
-            NUM_CHUNKS_W4,
-        >;
+        type THw4 =
+            PoseidonTweakHash<PARAMETER_LEN, HASH_LEN_FE, TWEAK_LEN_FE, CAPACITY, NUM_CHUNKS_W4>;
         type PRFw4 = ShakePRFtoF<HASH_LEN_FE>;
         type IEw4 = WinternitzEncoding<MHw4, CHUNK_SIZE_W4, NUM_CHUNKS_CHECKSUM_W4>;
         /// Instantiation with Lifetime 2^18, Winternitz encoding, chunk size w = 4
@@ -115,13 +100,8 @@ pub mod lifetime_2_to_the_18 {
             TWEAK_LEN_FE,
             MSG_LEN_FE,
         >;
-        type THw8 = PoseidonTweakHash<
-            PARAMETER_LEN,
-            HASH_LEN_FE,
-            TWEAK_LEN_FE,
-            CAPACITY,
-            NUM_CHUNKS_W8,
-        >;
+        type THw8 =
+            PoseidonTweakHash<PARAMETER_LEN, HASH_LEN_FE, TWEAK_LEN_FE, CAPACITY, NUM_CHUNKS_W8>;
         type PRFw8 = ShakePRFtoF<HASH_LEN_FE>;
         type IEw8 = WinternitzEncoding<MHw8, CHUNK_SIZE_W8, NUM_CHUNKS_CHECKSUM_W8>;
         /// Instantiation with Lifetime 2^18, Winternitz encoding, chunk size w = 8
@@ -212,13 +192,8 @@ pub mod lifetime_2_to_the_18 {
             TWEAK_LEN_FE,
             MSG_LEN_FE,
         >;
-        type THw1 = PoseidonTweakHash<
-            PARAMETER_LEN,
-            HASH_LEN_FE,
-            TWEAK_LEN_FE,
-            CAPACITY,
-            NUM_CHUNKS_W1,
-        >;
+        type THw1 =
+            PoseidonTweakHash<PARAMETER_LEN, HASH_LEN_FE, TWEAK_LEN_FE, CAPACITY, NUM_CHUNKS_W1>;
         type PRFw1 = ShakePRFtoF<HASH_LEN_FE>;
         type IEw1<const TARGET_SUM: usize> = TargetSumEncoding<MHw1, TARGET_SUM>;
         /// Instantiation with Lifetime 2^18, Target sum encoding, chunk size w = 1,
@@ -243,13 +218,8 @@ pub mod lifetime_2_to_the_18 {
             TWEAK_LEN_FE,
             MSG_LEN_FE,
         >;
-        type THw2 = PoseidonTweakHash<
-            PARAMETER_LEN,
-            HASH_LEN_FE,
-            TWEAK_LEN_FE,
-            CAPACITY,
-            NUM_CHUNKS_W2,
-        >;
+        type THw2 =
+            PoseidonTweakHash<PARAMETER_LEN, HASH_LEN_FE, TWEAK_LEN_FE, CAPACITY, NUM_CHUNKS_W2>;
         type PRFw2 = ShakePRFtoF<HASH_LEN_FE>;
         type IEw2<const TARGET_SUM: usize> = TargetSumEncoding<MHw2, TARGET_SUM>;
         /// Instantiation with Lifetime 2^18, Target sum encoding, chunk size w = 2,
@@ -274,13 +244,8 @@ pub mod lifetime_2_to_the_18 {
             TWEAK_LEN_FE,
             MSG_LEN_FE,
         >;
-        type THw4 = PoseidonTweakHash<
-            PARAMETER_LEN,
-            HASH_LEN_FE,
-            TWEAK_LEN_FE,
-            CAPACITY,
-            NUM_CHUNKS_W4,
-        >;
+        type THw4 =
+            PoseidonTweakHash<PARAMETER_LEN, HASH_LEN_FE, TWEAK_LEN_FE, CAPACITY, NUM_CHUNKS_W4>;
         type PRFw4 = ShakePRFtoF<HASH_LEN_FE>;
         type IEw4<const TARGET_SUM: usize> = TargetSumEncoding<MHw4, TARGET_SUM>;
         /// Instantiation with Lifetime 2^18, Target sum encoding, chunk size w = 4,
@@ -305,13 +270,8 @@ pub mod lifetime_2_to_the_18 {
             TWEAK_LEN_FE,
             MSG_LEN_FE,
         >;
-        type THw8 = PoseidonTweakHash<
-            PARAMETER_LEN,
-            HASH_LEN_FE,
-            TWEAK_LEN_FE,
-            CAPACITY,
-            NUM_CHUNKS_W8,
-        >;
+        type THw8 =
+            PoseidonTweakHash<PARAMETER_LEN, HASH_LEN_FE, TWEAK_LEN_FE, CAPACITY, NUM_CHUNKS_W8>;
         type PRFw8 = ShakePRFtoF<HASH_LEN_FE>;
         type IEw8<const TARGET_SUM: usize> = TargetSumEncoding<MHw8, TARGET_SUM>;
         /// Instantiation with Lifetime 2^18, Target sum encoding, chunk size w = 8,
@@ -426,13 +386,8 @@ pub mod lifetime_2_to_the_20 {
             TWEAK_LEN_FE,
             MSG_LEN_FE,
         >;
-        type THw1 = PoseidonTweakHash<
-            PARAMETER_LEN,
-            HASH_LEN_FE,
-            TWEAK_LEN_FE,
-            CAPACITY,
-            NUM_CHUNKS_W1,
-        >;
+        type THw1 =
+            PoseidonTweakHash<PARAMETER_LEN, HASH_LEN_FE, TWEAK_LEN_FE, CAPACITY, NUM_CHUNKS_W1>;
         type PRFw1 = ShakePRFtoF<HASH_LEN_FE>;
         type IEw1 = WinternitzEncoding<MHw1, CHUNK_SIZE_W1, NUM_CHUNKS_CHECKSUM_W1>;
         /// Instantiation with Lifetime 2^20, Winternitz encoding, chunk size w = 1
@@ -453,13 +408,8 @@ pub mod lifetime_2_to_the_20 {
             TWEAK_LEN_FE,
             MSG_LEN_FE,
         >;
-        type THw2 = PoseidonTweakHash<
-            PARAMETER_LEN,
-            HASH_LEN_FE,
-            TWEAK_LEN_FE,
-            CAPACITY,
-            NUM_CHUNKS_W2,
-        >;
+        type THw2 =
+            PoseidonTweakHash<PARAMETER_LEN, HASH_LEN_FE, TWEAK_LEN_FE, CAPACITY, NUM_CHUNKS_W2>;
         type PRFw2 = ShakePRFtoF<HASH_LEN_FE>;
         type IEw2 = WinternitzEncoding<MHw2, CHUNK_SIZE_W2, NUM_CHUNKS_CHECKSUM_W2>;
         /// Instantiation with Lifetime 2^20, Winternitz encoding, chunk size w = 2
@@ -480,13 +430,8 @@ pub mod lifetime_2_to_the_20 {
             TWEAK_LEN_FE,
             MSG_LEN_FE,
         >;
-        type THw4 = PoseidonTweakHash<
-            PARAMETER_LEN,
-            HASH_LEN_FE,
-            TWEAK_LEN_FE,
-            CAPACITY,
-            NUM_CHUNKS_W4,
-        >;
+        type THw4 =
+            PoseidonTweakHash<PARAMETER_LEN, HASH_LEN_FE, TWEAK_LEN_FE, CAPACITY, NUM_CHUNKS_W4>;
         type PRFw4 = ShakePRFtoF<HASH_LEN_FE>;
         type IEw4 = WinternitzEncoding<MHw4, CHUNK_SIZE_W4, NUM_CHUNKS_CHECKSUM_W4>;
         /// Instantiation with Lifetime 2^20, Winternitz encoding, chunk size w = 4
@@ -508,13 +453,8 @@ pub mod lifetime_2_to_the_20 {
             TWEAK_LEN_FE,
             MSG_LEN_FE,
         >;
-        type THw8 = PoseidonTweakHash<
-            PARAMETER_LEN,
-            HASH_LEN_FE_W8,
-            TWEAK_LEN_FE,
-            CAPACITY,
-            NUM_CHUNKS_W8,
-        >;
+        type THw8 =
+            PoseidonTweakHash<PARAMETER_LEN, HASH_LEN_FE_W8, TWEAK_LEN_FE, CAPACITY, NUM_CHUNKS_W8>;
         type PRFw8 = ShakePRFtoF<HASH_LEN_FE_W8>;
         type IEw8 = WinternitzEncoding<MHw8, CHUNK_SIZE_W8, NUM_CHUNKS_CHECKSUM_W8>;
         /// Instantiation with Lifetime 2^20, Winternitz encoding, chunk size w = 8
@@ -605,13 +545,8 @@ pub mod lifetime_2_to_the_20 {
             TWEAK_LEN_FE,
             MSG_LEN_FE,
         >;
-        type THw1 = PoseidonTweakHash<
-            PARAMETER_LEN,
-            HASH_LEN_FE,
-            TWEAK_LEN_FE,
-            CAPACITY,
-            NUM_CHUNKS_W1,
-        >;
+        type THw1 =
+            PoseidonTweakHash<PARAMETER_LEN, HASH_LEN_FE, TWEAK_LEN_FE, CAPACITY, NUM_CHUNKS_W1>;
         type PRFw1 = ShakePRFtoF<HASH_LEN_FE>;
         type IEw1<const TARGET_SUM: usize> = TargetSumEncoding<MHw1, TARGET_SUM>;
         /// Instantiation with Lifetime 2^20, Target sum encoding, chunk size w = 1,
@@ -636,13 +571,8 @@ pub mod lifetime_2_to_the_20 {
             TWEAK_LEN_FE,
             MSG_LEN_FE,
         >;
-        type THw2 = PoseidonTweakHash<
-            PARAMETER_LEN,
-            HASH_LEN_FE,
-            TWEAK_LEN_FE,
-            CAPACITY,
-            NUM_CHUNKS_W2,
-        >;
+        type THw2 =
+            PoseidonTweakHash<PARAMETER_LEN, HASH_LEN_FE, TWEAK_LEN_FE, CAPACITY, NUM_CHUNKS_W2>;
         type PRFw2 = ShakePRFtoF<HASH_LEN_FE>;
         type IEw2<const TARGET_SUM: usize> = TargetSumEncoding<MHw2, TARGET_SUM>;
         /// Instantiation with Lifetime 2^20, Target sum encoding, chunk size w = 2,
@@ -667,13 +597,8 @@ pub mod lifetime_2_to_the_20 {
             TWEAK_LEN_FE,
             MSG_LEN_FE,
         >;
-        type THw4 = PoseidonTweakHash<
-            PARAMETER_LEN,
-            HASH_LEN_FE,
-            TWEAK_LEN_FE,
-            CAPACITY,
-            NUM_CHUNKS_W4,
-        >;
+        type THw4 =
+            PoseidonTweakHash<PARAMETER_LEN, HASH_LEN_FE, TWEAK_LEN_FE, CAPACITY, NUM_CHUNKS_W4>;
         type PRFw4 = ShakePRFtoF<HASH_LEN_FE>;
         type IEw4<const TARGET_SUM: usize> = TargetSumEncoding<MHw4, TARGET_SUM>;
         /// Instantiation with Lifetime 2^20, Target sum encoding, chunk size w = 4,
@@ -699,13 +624,8 @@ pub mod lifetime_2_to_the_20 {
             TWEAK_LEN_FE,
             MSG_LEN_FE,
         >;
-        type THw8 = PoseidonTweakHash<
-            PARAMETER_LEN,
-            HASH_LEN_FE_W8,
-            TWEAK_LEN_FE,
-            CAPACITY,
-            NUM_CHUNKS_W8,
-        >;
+        type THw8 =
+            PoseidonTweakHash<PARAMETER_LEN, HASH_LEN_FE_W8, TWEAK_LEN_FE, CAPACITY, NUM_CHUNKS_W8>;
         type PRFw8 = ShakePRFtoF<HASH_LEN_FE_W8>;
         type IEw8<const TARGET_SUM: usize> = TargetSumEncoding<MHw8, TARGET_SUM>;
         /// Instantiation with Lifetime 2^20, Target sum encoding, chunk size w = 8,

--- a/src/signature/generalized_xmss/instantiations_sha.rs
+++ b/src/signature/generalized_xmss/instantiations_sha.rs
@@ -21,7 +21,7 @@ pub mod lifetime_2_to_the_18 {
         const HASH_LEN_W1: usize = 25;
         type THw1 = ShaTweakHash<PARAMETER_LEN, HASH_LEN_W1>;
         type PRFw1 = ShaPRF<HASH_LEN_W1>;
-        type IEw1 = WinternitzEncoding<MHw1, 8>;
+        type IEw1 = WinternitzEncoding<MHw1, CHUNK_SIZE_W1, 8>;
         /// Instantiation with Lifetime 2^18, Winternitz encoding, chunk size w = 1
         pub type SIGWinternitzLifetime18W1 =
             GeneralizedXMSSSignatureScheme<PRFw1, IEw1, THw1, LOG_LIFETIME>;
@@ -32,7 +32,7 @@ pub mod lifetime_2_to_the_18 {
         const HASH_LEN_W2: usize = 25;
         type THw2 = ShaTweakHash<PARAMETER_LEN, HASH_LEN_W2>;
         type PRFw2 = ShaPRF<HASH_LEN_W2>;
-        type IEw2 = WinternitzEncoding<MHw2, 4>;
+        type IEw2 = WinternitzEncoding<MHw2, CHUNK_SIZE_W2, 4>;
         /// Instantiation with Lifetime 2^18, Winternitz encoding, chunk size w = 2
         pub type SIGWinternitzLifetime18W2 =
             GeneralizedXMSSSignatureScheme<PRFw2, IEw2, THw2, LOG_LIFETIME>;
@@ -43,7 +43,7 @@ pub mod lifetime_2_to_the_18 {
         const HASH_LEN_W4: usize = 26;
         type THw4 = ShaTweakHash<PARAMETER_LEN, HASH_LEN_W4>;
         type PRFw4 = ShaPRF<HASH_LEN_W4>;
-        type IEw4 = WinternitzEncoding<MHw4, 3>;
+        type IEw4 = WinternitzEncoding<MHw4, CHUNK_SIZE_W4, 3>;
         /// Instantiation with Lifetime 2^18, Winternitz encoding, chunk size w = 4
         pub type SIGWinternitzLifetime18W4 =
             GeneralizedXMSSSignatureScheme<PRFw4, IEw4, THw4, LOG_LIFETIME>;
@@ -54,7 +54,7 @@ pub mod lifetime_2_to_the_18 {
         const HASH_LEN_W8: usize = 28;
         type THw8 = ShaTweakHash<PARAMETER_LEN, HASH_LEN_W8>;
         type PRFw8 = ShaPRF<HASH_LEN_W8>;
-        type IEw8 = WinternitzEncoding<MHw8, 2>;
+        type IEw8 = WinternitzEncoding<MHw8, CHUNK_SIZE_W8, 2>;
         /// Instantiation with Lifetime 2^18, Winternitz encoding, chunk size w = 8
         pub type SIGWinternitzLifetime18W8 =
             GeneralizedXMSSSignatureScheme<PRFw8, IEw8, THw8, LOG_LIFETIME>;
@@ -280,7 +280,7 @@ pub mod lifetime_2_to_the_20 {
         const HASH_LEN_W1: usize = 25;
         type THw1 = ShaTweakHash<PARAMETER_LEN, HASH_LEN_W1>;
         type PRFw1 = ShaPRF<HASH_LEN_W1>;
-        type IEw1 = WinternitzEncoding<MHw1, 8>;
+        type IEw1 = WinternitzEncoding<MHw1, CHUNK_SIZE_W1, 8>;
         /// Instantiation with Lifetime 2^20, Winternitz encoding, chunk size w = 1
         pub type SIGWinternitzLifetime20W1 =
             GeneralizedXMSSSignatureScheme<PRFw1, IEw1, THw1, LOG_LIFETIME>;
@@ -291,7 +291,7 @@ pub mod lifetime_2_to_the_20 {
         const HASH_LEN_W2: usize = 26;
         type THw2 = ShaTweakHash<PARAMETER_LEN, HASH_LEN_W2>;
         type PRFw2 = ShaPRF<HASH_LEN_W2>;
-        type IEw2 = WinternitzEncoding<MHw2, 4>;
+        type IEw2 = WinternitzEncoding<MHw2, CHUNK_SIZE_W2, 4>;
         /// Instantiation with Lifetime 2^20, Winternitz encoding, chunk size w = 2
         pub type SIGWinternitzLifetime20W2 =
             GeneralizedXMSSSignatureScheme<PRFw2, IEw2, THw2, LOG_LIFETIME>;
@@ -302,7 +302,7 @@ pub mod lifetime_2_to_the_20 {
         const HASH_LEN_W4: usize = 26;
         type THw4 = ShaTweakHash<PARAMETER_LEN, HASH_LEN_W4>;
         type PRFw4 = ShaPRF<HASH_LEN_W4>;
-        type IEw4 = WinternitzEncoding<MHw4, 3>;
+        type IEw4 = WinternitzEncoding<MHw4, CHUNK_SIZE_W4, 3>;
         /// Instantiation with Lifetime 2^20, Winternitz encoding, chunk size w = 4
         pub type SIGWinternitzLifetime20W4 =
             GeneralizedXMSSSignatureScheme<PRFw4, IEw4, THw4, LOG_LIFETIME>;
@@ -313,7 +313,7 @@ pub mod lifetime_2_to_the_20 {
         const HASH_LEN_W8: usize = 28;
         type THw8 = ShaTweakHash<PARAMETER_LEN, HASH_LEN_W8>;
         type PRFw8 = ShaPRF<HASH_LEN_W8>;
-        type IEw8 = WinternitzEncoding<MHw8, 2>;
+        type IEw8 = WinternitzEncoding<MHw8, CHUNK_SIZE_W8, 2>;
         /// Instantiation with Lifetime 2^20, Winternitz encoding, chunk size w = 8
         pub type SIGWinternitzLifetime20W8 =
             GeneralizedXMSSSignatureScheme<PRFw8, IEw8, THw8, LOG_LIFETIME>;

--- a/src/symmetric/message_hash.rs
+++ b/src/symmetric/message_hash.rs
@@ -12,7 +12,7 @@ pub trait MessageHash {
     type Parameter: Clone + Sized;
     type Randomness;
 
-    const NUM_CHUNKS: usize;
+    const DIMENSION: usize;
 
     /// Must be 1, 2, 4, or 8
     const CHUNK_SIZE: usize;
@@ -22,7 +22,7 @@ pub trait MessageHash {
 
     /// Applies the message hash to a parameter, an epoch,
     /// a randomness, and a message. It outputs a list of chunks.
-    /// The list contains NUM_CHUNKS many elements, each between
+    /// The list contains DIMENSION many elements, each between
     /// 0 and 2^CHUNK_SIZE - 1 (inclusive).
     fn apply(
         parameter: &Self::Parameter,

--- a/src/symmetric/message_hash.rs
+++ b/src/symmetric/message_hash.rs
@@ -12,10 +12,11 @@ pub trait MessageHash {
     type Parameter: Clone + Sized;
     type Randomness;
 
+    /// number of entries in a hash
     const DIMENSION: usize;
 
-    /// Must be 1, 2, 4, or 8
-    const CHUNK_SIZE: usize;
+    /// each hash entry is between 0 and BASE - 1
+    const BASE: usize;
 
     /// Generates a random domain element.
     fn rand<R: Rng>(rng: &mut R) -> Self::Randomness;
@@ -23,13 +24,13 @@ pub trait MessageHash {
     /// Applies the message hash to a parameter, an epoch,
     /// a randomness, and a message. It outputs a list of chunks.
     /// The list contains DIMENSION many elements, each between
-    /// 0 and 2^CHUNK_SIZE - 1 (inclusive).
+    /// 0 and BASE - 1 (inclusive).
     fn apply(
         parameter: &Self::Parameter,
         epoch: u32,
         randomness: &Self::Randomness,
         message: &[u8; MESSAGE_LENGTH],
-    ) -> Vec<u8>;
+    ) -> Vec<u16>;
 
     /// Function to check internal consistency of any given parameters
     /// For testing only, and expected to panic if something is wrong.
@@ -72,7 +73,7 @@ const fn isolate_chunk_from_byte(byte: u8, chunk_index: usize, chunk_size: usize
 /// many bits. For example, if `bytes` contains 6 elements, and
 /// `chunk_size` is 2, then the result contains 6 * (8/2) = 24 elements.
 ///  It is assumed that `chunk_size` divides 8 and is between 1 and 8.
-pub fn bytes_to_chunks(bytes: &[u8], chunk_size: usize) -> Vec<u8> {
+pub fn bytes_to_chunks(bytes: &[u8], chunk_size: usize) -> Vec<u16> {
     // Ensure chunk size divides 8 and is between 1 and 8
     assert!(chunk_size > 0 && chunk_size <= 8 && 8 % chunk_size == 0);
 
@@ -86,7 +87,7 @@ pub fn bytes_to_chunks(bytes: &[u8], chunk_size: usize) -> Vec<u8> {
         let byte = bytes[byte_index];
         // now isolate the chunk and store it
         let chunk_index_in_byte = chunk_index % chunks_per_byte;
-        let chunk = isolate_chunk_from_byte(byte, chunk_index_in_byte, chunk_size);
+        let chunk = isolate_chunk_from_byte(byte, chunk_index_in_byte, chunk_size) as u16;
         chunks.push(chunk);
     }
     chunks
@@ -133,7 +134,7 @@ mod tests {
         let chunks = bytes_to_chunks(&bytes, 8);
 
         assert_eq!(chunks.len(), 2);
-        assert_eq!(chunks[0], byte_a);
-        assert_eq!(chunks[1], byte_b);
+        assert_eq!(chunks[0], byte_a as u16);
+        assert_eq!(chunks[1], byte_b as u16);
     }
 }

--- a/src/symmetric/message_hash/poseidon.rs
+++ b/src/symmetric/message_hash/poseidon.rs
@@ -113,7 +113,7 @@ impl<
 
     type Randomness = [F; RAND_LEN];
 
-    const NUM_CHUNKS: usize = NUM_CHUNKS;
+    const DIMENSION: usize = NUM_CHUNKS;
 
     const CHUNK_SIZE: usize = CHUNK_SIZE;
 

--- a/src/symmetric/message_hash/poseidon.rs
+++ b/src/symmetric/message_hash/poseidon.rs
@@ -50,11 +50,11 @@ fn encode_epoch<const TWEAK_LEN_FE: usize>(epoch: u32) -> [F; TWEAK_LEN_FE] {
 
 /// Function to decode a vector of field elements into
 /// a vector of NUM_CHUNKS many chunks. One chunk is
-/// between 0 and 2^CHUNK_SIZE - 1 (inclusive).
-/// CHUNK_SIZE up to 8 (inclusive) is supported
-fn decode_to_chunks<const NUM_CHUNKS: usize, const CHUNK_SIZE: usize, const HASH_LEN_FE: usize>(
+/// between 0 and BASE - 1 (inclusive).
+/// BASE up to 2^16 (inclusive) is supported
+fn decode_to_chunks<const NUM_CHUNKS: usize, const BASE: usize, const HASH_LEN_FE: usize>(
     field_elements: &[F; HASH_LEN_FE],
-) -> [u8; NUM_CHUNKS] {
+) -> [u16; NUM_CHUNKS] {
     // Combine field elements into one big integer
     let p = BigUint::from(FqConfig::MODULUS);
     let mut acc = BigUint::ZERO;
@@ -62,11 +62,10 @@ fn decode_to_chunks<const NUM_CHUNKS: usize, const CHUNK_SIZE: usize, const HASH
         acc = &acc * &p + BigUint::from(fe.into_bigint());
     }
 
-    // Convert to base-(2^CHUNK_SIZE)
-    let base = (1 << CHUNK_SIZE) as u16;
+    // Convert to base-BASE
     std::array::from_fn(|_| {
-        let chunk = (&acc % base).try_into().unwrap();
-        acc /= base;
+        let chunk = (&acc % BASE).try_into().unwrap();
+        acc /= BASE;
         chunk
     })
 }
@@ -79,13 +78,13 @@ fn decode_to_chunks<const NUM_CHUNKS: usize, const CHUNK_SIZE: usize, const HASH
 /// HASH_LEN_FE specifies how many field elements the
 /// hash output needs to be before it is decoded to chunks.
 ///
-/// CHUNK_SIZE has to be 1,2,4, or 8.
+/// BASE must be at most 2^16
 pub struct PoseidonMessageHash<
     const PARAMETER_LEN: usize,
     const RAND_LEN: usize,
     const HASH_LEN_FE: usize,
     const NUM_CHUNKS: usize,
-    const CHUNK_SIZE: usize,
+    const BASE: usize,
     const TWEAK_LEN_FE: usize,
     const MSG_LEN_FE: usize,
 >;
@@ -95,7 +94,7 @@ impl<
         const RAND_LEN: usize,
         const HASH_LEN_FE: usize,
         const NUM_CHUNKS: usize,
-        const CHUNK_SIZE: usize,
+        const BASE: usize,
         const TWEAK_LEN_FE: usize,
         const MSG_LEN_FE: usize,
     > MessageHash
@@ -104,7 +103,7 @@ impl<
         RAND_LEN,
         HASH_LEN_FE,
         NUM_CHUNKS,
-        CHUNK_SIZE,
+        BASE,
         TWEAK_LEN_FE,
         MSG_LEN_FE,
     >
@@ -115,7 +114,7 @@ impl<
 
     const DIMENSION: usize = NUM_CHUNKS;
 
-    const CHUNK_SIZE: usize = CHUNK_SIZE;
+    const BASE: usize = BASE;
 
     fn rand<R: rand::Rng>(rng: &mut R) -> Self::Randomness {
         std::array::from_fn(|_| F::rand(rng))
@@ -126,7 +125,7 @@ impl<
         epoch: u32,
         randomness: &Self::Randomness,
         message: &[u8; MESSAGE_LENGTH],
-    ) -> Vec<u8> {
+    ) -> Vec<u16> {
         // We need a Poseidon instance
 
         // Note: This block should be changed if we decide to support other Poseidon
@@ -149,7 +148,7 @@ impl<
         let hash_fe = poseidon_compress(&instance, &combined_input);
 
         // decode field elements into chunks and return them
-        decode_to_chunks::<NUM_CHUNKS, CHUNK_SIZE, HASH_LEN_FE>(&hash_fe).to_vec()
+        decode_to_chunks::<NUM_CHUNKS, BASE, HASH_LEN_FE>(&hash_fe).to_vec()
     }
 
     #[cfg(test)]
@@ -158,6 +157,12 @@ impl<
         assert!(
             BigUint::from(FqConfig::MODULUS) < BigUint::from(u64::MAX),
             "The prime field used is too large"
+        );
+
+        // Base check
+        assert!(
+            Self::BASE <= 1 << 16,
+            "Poseidon Message Hash: Base must be at most 2^16"
         );
 
         // message check
@@ -191,16 +196,17 @@ impl<
                 .parse()
                 .unwrap(),
         ) * f64::from(HASH_LEN_FE as u32);
+        let chunk_size = f64::ceil(f64::log2(Self::BASE as f64)) as usize;
         assert!(
-            hash_bits <= f64::from((NUM_CHUNKS * CHUNK_SIZE) as u32),
-            "Poseidon Message hash. Parameter mismatch: not enough chunks to decode the hash"
+            hash_bits <= f64::from((NUM_CHUNKS * chunk_size) as u32),
+            "Poseidon Message hash. Parameter mismatch: not enough bits to decode the hash"
         );
     }
 }
 
 // Example instantiations
-pub type PoseidonMessageHash445 = PoseidonMessageHash<4, 4, 5, 128, 2, 2, 9>;
-pub type PoseidonMessageHashW1 = PoseidonMessageHash<5, 5, 5, 163, 1, 2, 9>;
+pub type PoseidonMessageHash445 = PoseidonMessageHash<4, 4, 5, 128, 4, 2, 9>;
+pub type PoseidonMessageHashW1 = PoseidonMessageHash<5, 5, 5, 163, 2, 2, 9>;
 
 #[cfg(test)]
 mod tests {
@@ -282,8 +288,8 @@ mod tests {
         let field_elements = [F::ZERO; 5];
 
         // Should decode to all zero chunks
-        let expected = [0u8; 8];
-        let result = decode_to_chunks::<8, 4, 5>(&field_elements);
+        let expected = [0u16; 8];
+        let result = decode_to_chunks::<8, 16, 5>(&field_elements);
         assert_eq!(result, expected);
     }
 
@@ -310,7 +316,7 @@ mod tests {
             acc /= 16u8;
         }
 
-        let result = decode_to_chunks::<4, 4, 2>(&input);
+        let result = decode_to_chunks::<4, 16, 2>(&input);
         assert_eq!(result, expected);
     }
 
@@ -334,39 +340,6 @@ mod tests {
         ];
 
         let result = encode_epoch::<4>(epoch);
-        assert_eq!(result, expected);
-    }
-
-    #[test]
-    fn test_decode_to_chunks_max_value() {
-        // Field modulus
-        let p = BigUint::from(FqConfig::MODULUS);
-
-        // Use all field elements set to p - 1
-        let input = [F::from(p.clone() - 1u32); 3];
-
-        // Compute combined input_uint:
-        //
-        // input_uint = (p - 1) + (p - 1) * p + (p - 1) * p^2
-        //           = (p^2 + p + 1) * (p - 1)
-        //
-        // We’ll expand it:
-        // = (p - 1) * (p^2 + p + 1)
-        // = p^3 - 1
-
-        let p2 = &p * &p;
-        let p3 = &p * &p2;
-        let input_uint = &p3 - 1u32;
-
-        // CHUNK_SIZE = 8 → max = 256
-        let mut acc = input_uint.clone();
-        let mut expected = [0u8; 8];
-        for i in 0..8 {
-            expected[i] = (&acc % 256u32).try_into().unwrap();
-            acc /= 256u32;
-        }
-
-        let result = decode_to_chunks::<8, 8, 3>(&input);
         assert_eq!(result, expected);
     }
 
@@ -506,9 +479,43 @@ mod tests {
     }
 
     #[test]
+    fn test_decode_to_chunks_max_value() {
+        // Field modulus
+        let p = BigUint::from(FqConfig::MODULUS);
+
+        // Use all field elements set to p - 1
+        let input = [F::from(p.clone() - 1u32); 3];
+
+        // Compute combined input_uint:
+        //
+        // input_uint = (p - 1) + (p - 1) * p + (p - 1) * p^2
+        //           = (p^2 + p + 1) * (p - 1)
+        //
+        // We’ll expand it:
+        // = (p - 1) * (p^2 + p + 1)
+        // = p^3 - 1
+
+        let p2 = &p * &p;
+        let p3 = &p * &p2;
+        let input_uint = &p3 - 1u32;
+
+        // CHUNK_SIZE = 8 / BASE = 256
+        let mut acc = input_uint.clone();
+        let mut expected = [0u16; 8];
+        for i in 0..8 {
+            expected[i] = (&acc % 256u32).try_into().unwrap();
+            acc /= 256u32;
+        }
+
+        let result = decode_to_chunks::<8, 256, 3>(&input);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
     fn test_decode_to_chunks_roundtrip_consistency() {
         const HASH_LEN_FE: usize = 4;
-        const CHUNK_SIZE: usize = 4; // 4 bits => base 16
+        const CHUNK_SIZE: usize = 4;
+        const BASE: usize = 1 << CHUNK_SIZE; // 16
         const NUM_CHUNKS: usize = 32;
 
         let mut rng = thread_rng();
@@ -525,10 +532,10 @@ mod tests {
         }
 
         // Decode to chunks
-        let chunks = decode_to_chunks::<NUM_CHUNKS, CHUNK_SIZE, HASH_LEN_FE>(&input_field_elements);
+        let chunks = decode_to_chunks::<NUM_CHUNKS, BASE, HASH_LEN_FE>(&input_field_elements);
 
-        // Reconstruct bigint from chunks using little-endian base-(2^CHUNK_SIZE)
-        let base = BigUint::from(1u8 << CHUNK_SIZE); // base = 16
+        // Reconstruct bigint from chunks using little-endian base-(BASE)
+        let base = BigUint::from(BASE);
         let mut reconstructed_bigint = BigUint::zero();
         for (i, &chunk) in chunks.iter().enumerate() {
             reconstructed_bigint += BigUint::from(chunk) * base.pow(i as u32);

--- a/src/symmetric/message_hash/sha.rs
+++ b/src/symmetric/message_hash/sha.rs
@@ -68,6 +68,10 @@ impl<
     #[cfg(test)]
     fn internal_consistency_check() {
         assert!(
+            [1, 2, 4, 8].contains(&CHUNK_SIZE),
+            "SHA Message Hash: Chunk Size must be 1, 2, 4, or 8"
+        );
+        assert!(
             PARAMETER_LEN < 256 / 8,
             "SHA Message Hash: Parameter Length must be less than 256 bit"
         );

--- a/src/symmetric/message_hash/sha.rs
+++ b/src/symmetric/message_hash/sha.rs
@@ -29,7 +29,7 @@ impl<
 
     type Randomness = [u8; RAND_LEN];
 
-    const NUM_CHUNKS: usize = NUM_CHUNKS;
+    const DIMENSION: usize = NUM_CHUNKS;
 
     const CHUNK_SIZE: usize = CHUNK_SIZE;
 

--- a/src/symmetric/message_hash/sha.rs
+++ b/src/symmetric/message_hash/sha.rs
@@ -31,7 +31,7 @@ impl<
 
     const DIMENSION: usize = NUM_CHUNKS;
 
-    const CHUNK_SIZE: usize = CHUNK_SIZE;
+    const BASE: usize = 1 << CHUNK_SIZE;
 
     fn rand<R: rand::Rng>(rng: &mut R) -> Self::Randomness {
         std::array::from_fn(|_| rng.gen())
@@ -42,7 +42,7 @@ impl<
         epoch: u32,
         randomness: &Self::Randomness,
         message: &[u8; MESSAGE_LENGTH],
-    ) -> Vec<u8> {
+    ) -> Vec<u16> {
         let mut hasher = Sha3_256::new();
 
         // first add randomness
@@ -62,7 +62,7 @@ impl<
         // finalize the hash, and take as many bytes as we need
         let hash = hasher.finalize();
         // turn the bytes in the hash into chunks
-        bytes_to_chunks(&hash[0..NUM_CHUNKS * CHUNK_SIZE / 8], Self::CHUNK_SIZE)
+        bytes_to_chunks(&hash[0..NUM_CHUNKS * CHUNK_SIZE / 8], CHUNK_SIZE)
     }
 
     #[cfg(test)]

--- a/src/symmetric/tweak_hash/poseidon.rs
+++ b/src/symmetric/tweak_hash/poseidon.rs
@@ -34,13 +34,11 @@ pub enum PoseidonTweak {
         epoch: u32,
         chain_index: u16,
         pos_in_chain: u16,
-    }
+    },
 }
 
-impl PoseidonTweak
-{
+impl PoseidonTweak {
     fn to_field_elements<const TWEAK_LEN: usize>(&self) -> [F; TWEAK_LEN] {
-
         // We first represent the entire tweak as one big integer
         let mut acc = match self {
             Self::TreeTweak {
@@ -210,13 +208,7 @@ impl<
         const CAPACITY: usize,
         const NUM_CHUNKS: usize,
     > TweakableHash
-    for PoseidonTweakHash<
-        PARAMETER_LEN,
-        HASH_LEN,
-        TWEAK_LEN,
-        CAPACITY,
-        NUM_CHUNKS,
-    >
+    for PoseidonTweakHash<PARAMETER_LEN, HASH_LEN, TWEAK_LEN, CAPACITY, NUM_CHUNKS>
 {
     type Parameter = [F; PARAMETER_LEN];
 
@@ -338,10 +330,10 @@ impl<
 }
 
 // Example instantiations
-pub type PoseidonTweak44 = PoseidonTweakHash< 4, 4, 3, 9, 128>;
+pub type PoseidonTweak44 = PoseidonTweakHash<4, 4, 3, 9, 128>;
 pub type PoseidonTweak37 = PoseidonTweakHash<3, 7, 3, 9, 128>;
-pub type PoseidonTweakW1L18 = PoseidonTweakHash< 5, 7, 2, 9, 163>;
-pub type PoseidonTweakW1L5 = PoseidonTweakHash< 5, 7, 2, 9, 163>;
+pub type PoseidonTweakW1L18 = PoseidonTweakHash<5, 7, 2, 9, 163>;
+pub type PoseidonTweakW1L5 = PoseidonTweakHash<5, 7, 2, 9, 163>;
 
 #[cfg(test)]
 mod tests {

--- a/src/symmetric/tweak_hash/poseidon.rs
+++ b/src/symmetric/tweak_hash/poseidon.rs
@@ -619,7 +619,7 @@ mod tests {
             .to_field_elements::<3>();
 
             if let Some((prev_level, prev_pos_in_level)) =
-                map.insert(tweak_encoding.clone(), (level, pos_in_level))
+                map.insert(tweak_encoding, (level, pos_in_level))
             {
                 assert_eq!(
                     (prev_level, prev_pos_in_level),
@@ -645,7 +645,7 @@ mod tests {
             }
             .to_field_elements::<3>();
 
-            if let Some(prev_pos_in_level) = map.insert(tweak_encoding.clone(), pos_in_level) {
+            if let Some(prev_pos_in_level) = map.insert(tweak_encoding, pos_in_level) {
                 assert_eq!(
                     prev_pos_in_level, pos_in_level,
                     "Collision detected for ({},{}) and ({},{}) with output {:?}",
@@ -665,7 +665,7 @@ mod tests {
             }
             .to_field_elements::<3>();
 
-            if let Some(prev_level) = map.insert(tweak_encoding.clone(), level) {
+            if let Some(prev_level) = map.insert(tweak_encoding, level) {
                 assert_eq!(
                     prev_level, level,
                     "Collision detected for ({},{}) and ({},{}) with output {:?}",
@@ -698,7 +698,7 @@ mod tests {
             }
             .to_field_elements::<3>();
 
-            if let Some(prev_input) = map.insert(tweak_encoding.clone(), input) {
+            if let Some(prev_input) = map.insert(tweak_encoding, input) {
                 assert_eq!(
                     prev_input, input,
                     "Collision detected for {:?} and {:?} with output {:?}",
@@ -723,7 +723,7 @@ mod tests {
             }
             .to_field_elements::<3>();
 
-            if let Some(prev_input) = map.insert(tweak_encoding.clone(), input) {
+            if let Some(prev_input) = map.insert(tweak_encoding, input) {
                 assert_eq!(
                     prev_input, input,
                     "Collision detected for {:?} and {:?} with output {:?}",
@@ -748,7 +748,7 @@ mod tests {
             }
             .to_field_elements::<3>();
 
-            if let Some(prev_input) = map.insert(tweak_encoding.clone(), input) {
+            if let Some(prev_input) = map.insert(tweak_encoding, input) {
                 assert_eq!(
                     prev_input, input,
                     "Collision detected for {:?} and {:?} with output {:?}",
@@ -773,7 +773,7 @@ mod tests {
             }
             .to_field_elements::<3>();
 
-            if let Some(prev_input) = map.insert(tweak_encoding.clone(), input) {
+            if let Some(prev_input) = map.insert(tweak_encoding, input) {
                 assert_eq!(
                     prev_input, input,
                     "Collision detected for {:?} and {:?} with output {:?}",


### PR DESCRIPTION

This PR makes a refactoring with regards to `CHUNK_SIZE` vs `BASE`.
Namely, before, traits like Incomparable Encodings or Message Hashes had a parameter `CHUNK_SIZE`,
and each chunk / entry of the hash / encoding was assumed to be represented by `CHUNK_SIZE` many bits.

With this PR, we instead have a parameter `BASE`, and entries take values from `0` to `BASE - 1`.
In particular, this will allow for encodings with non-power-of-two bases in the future.

Note: for plain Winternitz, we keep the restriction that chunk sizes must be 1,2,4, or 8 for simplicity.
To do so, we give the Winternitz encoding `CHUNK_SIZE` explicitly, because the message hash no longer 
has it.

Other changes:
- message hash now outputs `u16` (consistent with encoding)
- remove some unnecessary parameters for Poseidon tweak hash
- rename `NUM_CHUNKS` to `DIMENSION`
