### PR TITLE
Make pos_in_chain and chain_index u8

### DIFF
--- a/src/inc_encoding.rs
+++ b/src/inc_encoding.rs
@@ -10,8 +10,8 @@ pub type EncodingError = ();
 ///
 /// A codeword is a vector of a fixed dimension containing
 /// integer elements between 0 and BASE - 1.
-/// **WARNING**: We require BASE to be at most 1 << 16 to ensure that
-/// the entries fit into u16.
+/// **WARNING**: We require BASE to be at most 2^8 to ensure that
+/// the entries fit into u8.
 ///
 /// The main feature of these encodings is that no two distinct
 /// codewords are "comparable", i.e., for no two codewords
@@ -44,7 +44,7 @@ pub trait IncomparableEncoding {
         message: &[u8; MESSAGE_LENGTH],
         randomness: &Self::Randomness,
         epoch: u32,
-    ) -> Result<Vec<u16>, EncodingError>;
+    ) -> Result<Vec<u8>, EncodingError>;
 
     /// Function to check internal consistency of any given parameters
     /// For testing only, and expected to panic if something is wrong.

--- a/src/inc_encoding/basic_winternitz.rs
+++ b/src/inc_encoding/basic_winternitz.rs
@@ -50,7 +50,7 @@ impl<MH: MessageHash, const CHUNK_SIZE: usize, const NUM_CHUNKS_CHECKSUM: usize>
         message: &[u8; MESSAGE_LENGTH],
         randomness: &Self::Randomness,
         epoch: u32,
-    ) -> Result<Vec<u16>, super::EncodingError> {
+    ) -> Result<Vec<u8>, super::EncodingError> {
         // apply the message hash to get chunks
         let chunks_message = MH::apply(parameter, epoch, randomness, message);
 
@@ -71,7 +71,7 @@ impl<MH: MessageHash, const CHUNK_SIZE: usize, const NUM_CHUNKS_CHECKSUM: usize>
         Ok(chunks_message
             .iter()
             .chain(chunks_checksum.iter().take(NUM_CHUNKS_CHECKSUM))
-            .map(|&x| x as u16)
+            .map(|&x| x as u8)
             .collect())
     }
 
@@ -83,10 +83,14 @@ impl<MH: MessageHash, const CHUNK_SIZE: usize, const NUM_CHUNKS_CHECKSUM: usize>
             "Winternitz Encoding: Chunk Size must be 1, 2, 4, or 8"
         );
 
-        // base must not be too large
+        // base and dimension must not be too large
         assert!(
-            CHUNK_SIZE <= 16,
-            "Winternitz Encoding: Base must be at most 2^16"
+            CHUNK_SIZE <= 8,
+            "Winternitz Encoding: Base must be at most 2^8"
+        );
+        assert!(
+            Self::DIMENSION <= 1 << 8,
+            "Winternitz Encoding: Dimension must be at most 2^8"
         );
 
         // chunk size and base of MH must be consistent
@@ -94,6 +98,7 @@ impl<MH: MessageHash, const CHUNK_SIZE: usize, const NUM_CHUNKS_CHECKSUM: usize>
             MH::BASE == Self::BASE && MH::BASE == 1 << CHUNK_SIZE,
             "Winternitz Encoding: Base and chunk size not consistent with message hash"
         );
+
 
         // also check internal consistency of message hash
         MH::internal_consistency_check();

--- a/src/inc_encoding/basic_winternitz.rs
+++ b/src/inc_encoding/basic_winternitz.rs
@@ -99,7 +99,6 @@ impl<MH: MessageHash, const CHUNK_SIZE: usize, const NUM_CHUNKS_CHECKSUM: usize>
             "Winternitz Encoding: Base and chunk size not consistent with message hash"
         );
 
-
         // also check internal consistency of message hash
         MH::internal_consistency_check();
     }

--- a/src/inc_encoding/target_sum.rs
+++ b/src/inc_encoding/target_sum.rs
@@ -43,7 +43,7 @@ impl<MH: MessageHash, const TARGET_SUM: usize> IncomparableEncoding
         message: &[u8; MESSAGE_LENGTH],
         randomness: &Self::Randomness,
         epoch: u32,
-    ) -> Result<Vec<u16>, super::EncodingError> {
+    ) -> Result<Vec<u8>, super::EncodingError> {
         // apply the message hash first to get chunks
         let chunks = MH::apply(parameter, epoch, randomness, message);
         let sum: u32 = chunks.iter().map(|&x| x as u32).sum();
@@ -57,10 +57,14 @@ impl<MH: MessageHash, const TARGET_SUM: usize> IncomparableEncoding
 
     #[cfg(test)]
     fn internal_consistency_check() {
-        // base must not be too large
+        // base and dimension must not be too large
         assert!(
-            Self::BASE <= 1 << 16,
-            "Target Sum Encoding: Base must be at most 2^16"
+            Self::BASE <= 1 << 8,
+            "Target Sum Encoding: Base must be at most 2^8"
+        );
+        assert!(
+            Self::DIMENSION <= 1 << 8,
+            "Target Sum Encoding: Dimension must be at most 2^8"
         );
 
         // also check internal consistency of message hash

--- a/src/signature/generalized_xmss.rs
+++ b/src/signature/generalized_xmss.rs
@@ -115,7 +115,7 @@ where
                         chain::<TH>(
                             &parameter,
                             epoch as u32,
-                            chain_index as u16,
+                            chain_index as u8,
                             0,
                             chain_length - 1,
                             &start,
@@ -199,7 +199,7 @@ where
             let hash_in_chain = chain::<TH>(
                 &sk.parameter,
                 epoch,
-                chain_index as u16,
+                chain_index as u8,
                 0,
                 steps as usize,
                 &start,
@@ -242,13 +242,14 @@ where
         for (chain_index, xi) in x.iter().enumerate() {
             // If the signer has already walked x[i] steps, then we need
             // to walk chain_length - 1 - x[i] steps to reach the end of the chain
-            let steps = (chain_length - 1) as u16 - xi;
+            // Note: by our consistency checks, we have chain_length <= 2^8, so chain_length - 1 fits into u8
+            let steps = (chain_length - 1) as u8 - xi;
             let start_pos_in_chain = *xi;
             let start = &sig.hashes[chain_index];
             let end = chain::<TH>(
                 &pk.parameter,
                 epoch,
-                chain_index as u16,
+                chain_index as u8,
                 start_pos_in_chain,
                 steps as usize,
                 start,
@@ -274,6 +275,14 @@ where
         PRF::internal_consistency_check();
         IE::internal_consistency_check();
         TH::internal_consistency_check();
+
+        // assert BASE and DIMENSION are small enough to make sure that we can fit
+        // pos_in_chain and chain_index in u8.
+
+        // TODO: add test for max values
+
+        assert!(IE::BASE <= 1 << 8, "Generalized XMSS: Encoding base too large, must be at most 2^8");
+        assert!(IE::DIMENSION <= 1 << 8, "Generalized XMSS: Encoding dimension too large, must be at most 2^8");
     }
 }
 

--- a/src/signature/generalized_xmss.rs
+++ b/src/signature/generalized_xmss.rs
@@ -279,10 +279,14 @@ where
         // assert BASE and DIMENSION are small enough to make sure that we can fit
         // pos_in_chain and chain_index in u8.
 
-        // TODO: add test for max values
-
-        assert!(IE::BASE <= 1 << 8, "Generalized XMSS: Encoding base too large, must be at most 2^8");
-        assert!(IE::DIMENSION <= 1 << 8, "Generalized XMSS: Encoding dimension too large, must be at most 2^8");
+        assert!(
+            IE::BASE <= 1 << 8,
+            "Generalized XMSS: Encoding base too large, must be at most 2^8"
+        );
+        assert!(
+            IE::DIMENSION <= 1 << 8,
+            "Generalized XMSS: Encoding dimension too large, must be at most 2^8"
+        );
     }
 }
 
@@ -298,7 +302,9 @@ mod tests {
         signature::test_templates::_test_signature_scheme_correctness,
         symmetric::{
             message_hash::{
-                poseidon::PoseidonMessageHashW1, sha::ShaMessageHash192x3, MessageHash,
+                poseidon::PoseidonMessageHashW1,
+                sha::{ShaMessageHash, ShaMessageHash192x3},
+                MessageHash,
             },
             prf::{sha::ShaPRF, shake_to_field::ShakePRFtoF},
             tweak_hash::{poseidon::PoseidonTweakW1L5, sha::ShaTweak192192},
@@ -327,6 +333,7 @@ mod tests {
         _test_signature_scheme_correctness::<SIG>(0);
         _test_signature_scheme_correctness::<SIG>(11);
     }
+
     #[test]
     pub fn test_winternitz_poseidon() {
         // Note: do not use these parameters, they are just for testing
@@ -391,5 +398,43 @@ mod tests {
         _test_signature_scheme_correctness::<SIG>(19);
         _test_signature_scheme_correctness::<SIG>(0);
         _test_signature_scheme_correctness::<SIG>(11);
+    }
+
+    #[test]
+    pub fn test_large_base_sha() {
+        // Note: do not use these parameters, they are just for testing
+        type PRF = ShaPRF<24>;
+        type TH = ShaTweak192192;
+
+        // use chunk size 8
+        type MH = ShaMessageHash<24, 8, 32, 8>;
+        const TARGET_SUM: usize = 1 << 12;
+        type IE = TargetSumEncoding<MH, TARGET_SUM>;
+        const LOG_LIFETIME: usize = 9;
+        type SIG = GeneralizedXMSSSignatureScheme<PRF, IE, TH, LOG_LIFETIME>;
+
+        SIG::internal_consistency_check();
+
+        _test_signature_scheme_correctness::<SIG>(0);
+        _test_signature_scheme_correctness::<SIG>(11);
+    }
+
+    #[test]
+    pub fn test_large_dimension_sha() {
+        // Note: do not use these parameters, they are just for testing
+        type PRF = ShaPRF<24>;
+        type TH = ShaTweak192192;
+
+        // use 256 chunks
+        type MH = ShaMessageHash<24, 8, 256, 1>;
+        const TARGET_SUM: usize = 128;
+        type IE = TargetSumEncoding<MH, TARGET_SUM>;
+        const LOG_LIFETIME: usize = 9;
+        type SIG = GeneralizedXMSSSignatureScheme<PRF, IE, TH, LOG_LIFETIME>;
+
+        SIG::internal_consistency_check();
+
+        _test_signature_scheme_correctness::<SIG>(2);
+        _test_signature_scheme_correctness::<SIG>(19);
     }
 }

--- a/src/symmetric/message_hash.rs
+++ b/src/symmetric/message_hash.rs
@@ -8,6 +8,8 @@ use crate::MESSAGE_LENGTH;
 /// message hashing. Specifically, it contains one more input,
 /// and is always executed with respect to epochs, i.e., tweaks
 /// are implicitly derived from the epoch.
+///
+/// Note that BASE must be at most 2^8, as we encode chunks as u8.
 pub trait MessageHash {
     type Parameter: Clone + Sized;
     type Randomness;
@@ -30,7 +32,7 @@ pub trait MessageHash {
         epoch: u32,
         randomness: &Self::Randomness,
         message: &[u8; MESSAGE_LENGTH],
-    ) -> Vec<u16>;
+    ) -> Vec<u8>;
 
     /// Function to check internal consistency of any given parameters
     /// For testing only, and expected to panic if something is wrong.
@@ -73,7 +75,7 @@ const fn isolate_chunk_from_byte(byte: u8, chunk_index: usize, chunk_size: usize
 /// many bits. For example, if `bytes` contains 6 elements, and
 /// `chunk_size` is 2, then the result contains 6 * (8/2) = 24 elements.
 ///  It is assumed that `chunk_size` divides 8 and is between 1 and 8.
-pub fn bytes_to_chunks(bytes: &[u8], chunk_size: usize) -> Vec<u16> {
+pub fn bytes_to_chunks(bytes: &[u8], chunk_size: usize) -> Vec<u8> {
     // Ensure chunk size divides 8 and is between 1 and 8
     assert!(chunk_size > 0 && chunk_size <= 8 && 8 % chunk_size == 0);
 
@@ -87,7 +89,7 @@ pub fn bytes_to_chunks(bytes: &[u8], chunk_size: usize) -> Vec<u16> {
         let byte = bytes[byte_index];
         // now isolate the chunk and store it
         let chunk_index_in_byte = chunk_index % chunks_per_byte;
-        let chunk = isolate_chunk_from_byte(byte, chunk_index_in_byte, chunk_size) as u16;
+        let chunk = isolate_chunk_from_byte(byte, chunk_index_in_byte, chunk_size);
         chunks.push(chunk);
     }
     chunks
@@ -134,7 +136,7 @@ mod tests {
         let chunks = bytes_to_chunks(&bytes, 8);
 
         assert_eq!(chunks.len(), 2);
-        assert_eq!(chunks[0], byte_a as u16);
-        assert_eq!(chunks[1], byte_b as u16);
+        assert_eq!(chunks[0], byte_a);
+        assert_eq!(chunks[1], byte_b);
     }
 }

--- a/src/symmetric/message_hash/poseidon.rs
+++ b/src/symmetric/message_hash/poseidon.rs
@@ -176,7 +176,7 @@ impl<
         );
 
         // how many bits can be represented by one field element
-        let bits_per_fe = f64::ceil(f64::log2(
+        let bits_per_fe = f64::floor(f64::log2(
             BigUint::from(FqConfig::MODULUS)
                 .to_string()
                 .parse()

--- a/src/symmetric/message_hash/poseidon.rs
+++ b/src/symmetric/message_hash/poseidon.rs
@@ -51,10 +51,10 @@ fn encode_epoch<const TWEAK_LEN_FE: usize>(epoch: u32) -> [F; TWEAK_LEN_FE] {
 /// Function to decode a vector of field elements into
 /// a vector of DIMENSION many chunks. One chunk is
 /// between 0 and BASE - 1 (inclusive).
-/// BASE up to 2^16 (inclusive) is supported
+/// BASE up to 2^8 (inclusive) is supported
 fn decode_to_chunks<const DIMENSION: usize, const BASE: usize, const HASH_LEN_FE: usize>(
     field_elements: &[F; HASH_LEN_FE],
-) -> [u16; DIMENSION] {
+) -> [u8; DIMENSION] {
     // Combine field elements into one big integer
     let p = BigUint::from(FqConfig::MODULUS);
     let mut acc = BigUint::ZERO;
@@ -125,7 +125,7 @@ impl<
         epoch: u32,
         randomness: &Self::Randomness,
         message: &[u8; MESSAGE_LENGTH],
-    ) -> Vec<u16> {
+    ) -> Vec<u8> {
         // We need a Poseidon instance
         let instance = Poseidon2::new(&POSEIDON2_BABYBEAR_24_PARAMS);
 
@@ -165,10 +165,14 @@ impl<
             "The prime field used is too large"
         );
 
-        // Base check
+        // Base and dimension check
         assert!(
-            Self::BASE <= 1 << 16,
-            "Poseidon Message Hash: Base must be at most 2^16"
+            Self::BASE <= 1 << 8,
+            "Poseidon Message Hash: Base must be at most 2^8"
+        );
+        assert!(
+            Self::DIMENSION <= 1 << 8,
+            "Poseidon Message Hash: Dimension must be at most 2^8"
         );
 
         // how many bits can be represented by one field element
@@ -281,44 +285,6 @@ mod tests {
             "rand generated identical elements in all {} trials",
             K
         );
-    }
-
-    #[test]
-    fn test_decode_to_chunks_all_zeros() {
-        // All field elements are zero
-        let field_elements = [F::ZERO; 5];
-
-        // Should decode to all zero chunks
-        let expected = [0u16; 8];
-        let result = decode_to_chunks::<8, 16, 5>(&field_elements);
-        assert_eq!(result, expected);
-    }
-
-    #[test]
-    fn test_decode_to_chunks_simple_value() {
-        // Field modulus
-        let p = BigUint::from(FqConfig::MODULUS);
-
-        // Create field elements
-        let input = [F::from(1u64), F::from(2u64)];
-        let input_uint = BigUint::from(2u64) * &p + BigUint::from(1u64);
-
-        // CHUNK_SIZE = 4 => max value = 2^4 = 16
-        // Split input_uint = 2p + 1 into base-16 digits (little endian)
-        //
-        // Example:
-        //   input_uint = D_0 + 16*D_1 + 16^2*D_2 + ...
-        //   We compute D_i = input_uint % 16, then divide by 16
-
-        let mut acc = input_uint.clone();
-        let mut expected = [0; 4];
-        for i in 0..4 {
-            expected[i] = (&acc % 16u8).try_into().unwrap();
-            acc /= 16u8;
-        }
-
-        let result = decode_to_chunks::<4, 16, 2>(&input);
-        assert_eq!(result, expected);
     }
 
     #[test]
@@ -480,6 +446,44 @@ mod tests {
     }
 
     #[test]
+    fn test_decode_to_chunks_all_zeros() {
+        // All field elements are zero
+        let field_elements = [F::ZERO; 5];
+
+        // Should decode to all zero chunks
+        let expected = [0u8; 8];
+        let result = decode_to_chunks::<8, 16, 5>(&field_elements);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_decode_to_chunks_simple_value() {
+        // Field modulus
+        let p = BigUint::from(FqConfig::MODULUS);
+
+        // Create field elements
+        let input = [F::from(1u64), F::from(2u64)];
+        let input_uint = BigUint::from(2u64) * &p + BigUint::from(1u64);
+
+        // CHUNK_SIZE = 4 => max value = 2^4 = 16
+        // Split input_uint = 2p + 1 into base-16 digits (little endian)
+        //
+        // Example:
+        //   input_uint = D_0 + 16*D_1 + 16^2*D_2 + ...
+        //   We compute D_i = input_uint % 16, then divide by 16
+
+        let mut acc = input_uint.clone();
+        let mut expected = [0; 4];
+        for i in 0..4 {
+            expected[i] = (&acc % 16u8).try_into().unwrap();
+            acc /= 16u8;
+        }
+
+        let result = decode_to_chunks::<4, 16, 2>(&input);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
     fn test_decode_to_chunks_max_value() {
         // Field modulus
         let p = BigUint::from(FqConfig::MODULUS);
@@ -502,7 +506,7 @@ mod tests {
 
         // CHUNK_SIZE = 8 / BASE = 256
         let mut acc = input_uint.clone();
-        let mut expected = [0u16; 8];
+        let mut expected = [0u8; 8];
         for i in 0..8 {
             expected[i] = (&acc % 256u32).try_into().unwrap();
             acc /= 256u32;

--- a/src/symmetric/message_hash/poseidon.rs
+++ b/src/symmetric/message_hash/poseidon.rs
@@ -78,7 +78,7 @@ fn decode_to_chunks<const DIMENSION: usize, const BASE: usize, const HASH_LEN_FE
 /// HASH_LEN_FE specifies how many field elements the
 /// hash output needs to be before it is decoded to chunks.
 ///
-/// BASE must be at most 2^16
+/// BASE and DIMENSION must be at most 2^8
 pub struct PoseidonMessageHash<
     const PARAMETER_LEN: usize,
     const RAND_LEN_FE: usize,

--- a/src/symmetric/message_hash/sha.rs
+++ b/src/symmetric/message_hash/sha.rs
@@ -84,8 +84,8 @@ impl<
             "SHA Message Hash: Randomness Length must be non-zero"
         );
         assert!(
-            NUM_CHUNKS * CHUNK_SIZE < 256,
-            "SHA Message Hash: Hash Length (= NUM_CHUNKS * CHUNK_SIZE) must be less than 256 bit"
+            NUM_CHUNKS * CHUNK_SIZE <= 256,
+            "SHA Message Hash: Hash Length (= NUM_CHUNKS * CHUNK_SIZE) must be at most 256 bit"
         );
         assert!(
             Self::BASE <= 1 << 8,

--- a/src/symmetric/message_hash/sha.rs
+++ b/src/symmetric/message_hash/sha.rs
@@ -85,7 +85,7 @@ impl<
         );
         assert!(
             NUM_CHUNKS * CHUNK_SIZE <= 256,
-            "SHA Message Hash: Hash Length (= NUM_CHUNKS * CHUNK_SIZE) must be at most 256 bit"
+            "SHA Message Hash: Hash Length (= NUM_CHUNKS * CHUNK_SIZE) must be at most 256 bits"
         );
         assert!(
             Self::BASE <= 1 << 8,

--- a/src/symmetric/message_hash/sha.rs
+++ b/src/symmetric/message_hash/sha.rs
@@ -42,7 +42,7 @@ impl<
         epoch: u32,
         randomness: &Self::Randomness,
         message: &[u8; MESSAGE_LENGTH],
-    ) -> Vec<u16> {
+    ) -> Vec<u8> {
         let mut hasher = Sha3_256::new();
 
         // first add randomness
@@ -86,6 +86,14 @@ impl<
         assert!(
             NUM_CHUNKS * CHUNK_SIZE < 256,
             "SHA Message Hash: Hash Length (= NUM_CHUNKS * CHUNK_SIZE) must be less than 256 bit"
+        );
+        assert!(
+            Self::BASE <= 1 << 8,
+            "SHA Message Hash: Base must be at most 2^8"
+        );
+        assert!(
+            Self::DIMENSION <= 1 << 8,
+            "SHA Message Hash: Dimension must be at most 2^8"
         );
     }
 }

--- a/src/symmetric/tweak_hash.rs
+++ b/src/symmetric/tweak_hash.rs
@@ -29,7 +29,7 @@ pub trait TweakableHash {
 
     /// Returns a tweak to be used in chains.
     /// Note: this is assumed to be distinct from the outputs of tree_tweak
-    fn chain_tweak(epoch: u32, chain_index: u16, pos_in_chain: u16) -> Self::Tweak;
+    fn chain_tweak(epoch: u32, chain_index: u8, pos_in_chain: u8) -> Self::Tweak;
 
     /// Applies the tweakable hash to parameter, tweak, and message.
     fn apply(
@@ -54,8 +54,8 @@ pub trait TweakableHash {
 pub(crate) fn chain<TH: TweakableHash>(
     parameter: &TH::Parameter,
     epoch: u32,
-    chain_index: u16,
-    start_pos_in_chain: u16,
+    chain_index: u8,
+    start_pos_in_chain: u8,
     steps: usize,
     start: &TH::Domain,
 ) -> TH::Domain {
@@ -64,7 +64,7 @@ pub(crate) fn chain<TH: TweakableHash>(
 
     // otherwise, walk the right amount of steps
     for j in 0..steps {
-        let tweak = TH::chain_tweak(epoch, chain_index, start_pos_in_chain + (j as u16) + 1);
+        let tweak = TH::chain_tweak(epoch, chain_index, start_pos_in_chain + (j as u8) + 1u8);
         current = TH::apply(parameter, &tweak, &[current]);
     }
 
@@ -110,7 +110,43 @@ mod tests {
                 &parameter,
                 epoch,
                 chain_index,
-                steps_a as u16,
+                steps_a as u8,
+                steps_b,
+                &intermediate,
+            );
+
+            // should be the same
+            assert_eq!(end_direct, end_indirect);
+        }
+    }
+
+    #[test]
+    fn test_chain_associative_max_value() {
+        let mut rng = thread_rng();
+
+        // we test that first walking k steps, and then walking the remaining steps
+        // is the same as directly walking all steps.
+
+        let epoch = 12;
+        let chain_index = 210;
+        let parameter = TestTH::rand_parameter(&mut rng);
+        let start = TestTH::rand_domain(&mut rng);
+        let total_steps = 255; // max if we say that pos_in_chain is u8
+
+        // walking directly
+        let end_direct = chain::<TestTH>(&parameter, epoch, chain_index, 0, total_steps, &start);
+
+        for split in 0..=total_steps {
+            let steps_a = split;
+            let steps_b = total_steps - split;
+
+            // walking indirectly
+            let intermediate = chain::<TestTH>(&parameter, epoch, chain_index, 0, steps_a, &start);
+            let end_indirect = chain::<TestTH>(
+                &parameter,
+                epoch,
+                chain_index,
+                steps_a as u8,
                 steps_b,
                 &intermediate,
             );

--- a/src/symmetric/tweak_hash.rs
+++ b/src/symmetric/tweak_hash.rs
@@ -131,7 +131,7 @@ mod tests {
         let chain_index = 210;
         let parameter = TestTH::rand_parameter(&mut rng);
         let start = TestTH::rand_domain(&mut rng);
-        let total_steps = u8::MAX; // max if we say that pos_in_chain is u8
+        let total_steps = u8::MAX as usize; // max if we say that pos_in_chain is u8
 
         // walking directly
         let end_direct = chain::<TestTH>(&parameter, epoch, chain_index, 0, total_steps, &start);

--- a/src/symmetric/tweak_hash.rs
+++ b/src/symmetric/tweak_hash.rs
@@ -131,7 +131,7 @@ mod tests {
         let chain_index = 210;
         let parameter = TestTH::rand_parameter(&mut rng);
         let start = TestTH::rand_domain(&mut rng);
-        let total_steps = 255; // max if we say that pos_in_chain is u8
+        let total_steps = u8::MAX; // max if we say that pos_in_chain is u8
 
         // walking directly
         let end_direct = chain::<TestTH>(&parameter, epoch, chain_index, 0, total_steps, &start);

--- a/src/symmetric/tweak_hash/poseidon.rs
+++ b/src/symmetric/tweak_hash/poseidon.rs
@@ -316,7 +316,7 @@ impl<
             "Poseidon Tweak Tree Hash: Input lengths too large for Poseidon instance"
         );
 
-        let bits_per_fe = f64::ceil(f64::log2(
+        let bits_per_fe = f64::floor(f64::log2(
             BigUint::from(FqConfig::MODULUS)
                 .to_string()
                 .parse()

--- a/src/symmetric/tweak_hash/poseidon.rs
+++ b/src/symmetric/tweak_hash/poseidon.rs
@@ -307,7 +307,6 @@ impl<
             CAPACITY < 24,
             "Poseidon Tweak Chain Hash: Capacity must be less than 24"
         );
-
         assert!(
             PARAMETER_LEN + TWEAK_LEN + HASH_LEN <= 16,
             "Poseidon Tweak Chain Hash: Input lengths too large for Poseidon instance"
@@ -316,16 +315,32 @@ impl<
             PARAMETER_LEN + TWEAK_LEN + 2 * HASH_LEN <= 24,
             "Poseidon Tweak Tree Hash: Input lengths too large for Poseidon instance"
         );
-        let state_bits = f64::log2(
+
+        let bits_per_fe = f64::ceil(f64::log2(
             BigUint::from(FqConfig::MODULUS)
                 .to_string()
                 .parse()
                 .unwrap(),
-        ) * f64::from(24_u32);
+        ));
+        let state_bits = bits_per_fe * f64::from(24_u32);
         assert!(
             state_bits >= f64::from((DOMAIN_PARAMETERS_LENGTH * 32) as u32),
             "Poseidon Tweak Leaf Hash: not enough field elements to hash the domain separator"
         );
+
+
+        let bits_for_tree_tweak = f64::from(32 + 8_u32);
+        let bits_for_chain_tweak = f64::from(32 + 16 + 16 + 8_u32);
+        let tweak_fe_bits = bits_per_fe * f64::from(TWEAK_LEN as u32);
+        assert!(
+            tweak_fe_bits >= bits_for_tree_tweak,
+            "Poseidon Tweak Hash: not enough field elements to encode the tree tweak"
+        );
+        assert!(
+            tweak_fe_bits >= bits_for_chain_tweak,
+            "Poseidon Tweak Hash: not enough field elements to encode the chain tweak"
+        );
+
     }
 }
 

--- a/src/symmetric/tweak_hash/poseidon.rs
+++ b/src/symmetric/tweak_hash/poseidon.rs
@@ -328,7 +328,6 @@ impl<
             "Poseidon Tweak Leaf Hash: not enough field elements to hash the domain separator"
         );
 
-
         let bits_for_tree_tweak = f64::from(32 + 8_u32);
         let bits_for_chain_tweak = f64::from(32 + 8 + 8 + 8_u32);
         let tweak_fe_bits = bits_per_fe * f64::from(TWEAK_LEN as u32);
@@ -340,7 +339,6 @@ impl<
             tweak_fe_bits >= bits_for_chain_tweak,
             "Poseidon Tweak Hash: not enough field elements to encode the chain tweak"
         );
-
     }
 }
 

--- a/src/symmetric/tweak_hash/sha.rs
+++ b/src/symmetric/tweak_hash/sha.rs
@@ -12,8 +12,8 @@ pub enum ShaTweak {
     },
     ChainTweak {
         epoch: u32,
-        chain_index: u16,
-        pos_in_chain: u16,
+        chain_index: u8,
+        pos_in_chain: u8,
     },
 }
 
@@ -88,7 +88,7 @@ impl<const PARAMETER_LEN: usize, const HASH_LEN: usize> TweakableHash
         }
     }
 
-    fn chain_tweak(epoch: u32, chain_index: u16, pos_in_chain: u16) -> Self::Tweak {
+    fn chain_tweak(epoch: u32, chain_index: u8, pos_in_chain: u8) -> Self::Tweak {
         ShaTweak::ChainTweak {
             epoch,
             chain_index,


### PR DESCRIPTION
This PR changes `pos_in_chain` and `chain_index` to `u8`, which is sufficient for `BASE <= 256` and `DIMENSION <= 256` (which we always have). 

This is useful because we can then use only two field elements to encode all tweaks.