### PR TITLE
generalized xmss: better parallelization for sign function

### DIFF
--- a/src/signature/generalized_xmss.rs
+++ b/src/signature/generalized_xmss.rs
@@ -155,17 +155,33 @@ where
 
         // now, we need to encode our message using the incomparable encoding.
         // we retry until we get a valid codeword, or until we give up.
-        //
-        // `find_map` is a compact way to search for the first success.
-        let (rho, x) = (0..IE::MAX_TRIES)
-            .find_map(|_| {
-                // sample a randomness and try to encode the message
-                let rho = IE::rand(rng);
-                IE::encode(&sk.parameter.into(), message, &rho, epoch)
-                    .ok()
-                    .map(|x| (rho, x))
-            })
-            .ok_or(SigningError::UnluckyFailure)?;
+        let max_tries = IE::MAX_TRIES;
+        let mut attempts = 0;
+        let mut x = None;
+        let mut rho = None;
+        while attempts < max_tries {
+            // sample a randomness and try to encode the message
+            let curr_rho = IE::rand(rng);
+            let curr_x = IE::encode(&sk.parameter.into(), message, &curr_rho, epoch);
+
+            // check if we have found a valid codeword, and if so, stop searching
+            if curr_x.is_ok() {
+                rho = Some(curr_rho);
+                x = curr_x.ok().map(Some).unwrap_or(None);
+                break;
+            }
+
+            attempts += 1;
+        }
+
+        // if we have not found a valid codeword, return an error
+        if x.is_none() {
+            return Err(SigningError::UnluckyFailure);
+        }
+
+        // otherwise, unwrap x and rho
+        let x = x.unwrap();
+        let rho = rho.unwrap();
 
         // we will include rho in the signature, and
         // we use x to determine how far the signer walks in the chains

--- a/src/signature/generalized_xmss.rs
+++ b/src/signature/generalized_xmss.rs
@@ -167,11 +167,11 @@ where
             })
             .ok_or(SigningError::UnluckyFailure)?;
 
-        // The number of chains must match the number of chunks in the codeword.
+        // we will include rho in the signature, and
+        // we use x to determine how far the signer walks in the chains
         let num_chains = IE::DIMENSION;
-        assert_eq!(
-            x.len(),
-            num_chains,
+        assert!(
+            x.len() == num_chains,
             "Encoding is broken: returned too many or too few chunks."
         );
 


### PR DESCRIPTION
By computing the hash values in parallel, I've the following benchmark results (just ran smallest ones to have something reasonable on my laptop):

```shell
     Running benches/benchmark.rs (target/release/deps/benchmark-ea651d074821cbb7)
Gnuplot not found, using plotters backend
Poseidon - Scheme: Winternitz, Lifetime 2^18, w = 1/- sign
                        time:   [181.80 µs 183.59 µs 185.43 µs]
                        change: [-65.898% -65.575% -65.245%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
Poseidon - Scheme: Winternitz, Lifetime 2^18, w = 1/- verify
                        time:   [612.61 µs 614.03 µs 615.97 µs]
                        change: [-0.7363% -0.4917% -0.1603%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

Poseidon - Scheme: Winternitz, Lifetime 2^18, w = 2/- sign
                        time:   [160.21 µs 160.84 µs 161.46 µs]
                        change: [-66.057% -65.936% -65.797%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) low mild
Poseidon - Scheme: Winternitz, Lifetime 2^18, w = 2/- verify
                        time:   [552.95 µs 553.89 µs 554.97 µs]
                        change: [-2.9153% -1.3321% -0.4198%] (p = 0.04 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

Poseidon - Scheme: Winternitz, Lifetime 2^18, w = 4/- sign
                        time:   [248.87 µs 249.82 µs 250.86 µs]
                        change: [-69.661% -69.517% -69.360%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) low mild
  3 (3.00%) high mild
  1 (1.00%) high severe
Poseidon - Scheme: Winternitz, Lifetime 2^18, w = 4/- verify
                        time:   [976.32 µs 978.60 µs 980.93 µs]
                        change: [-0.7553% -0.4219% -0.0847%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

```