### PR TITLE
hypercube: add proptest for map_vertex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ dashmap = "6.1.0"
 
 [dev-dependencies]
 criterion = "0.5"
+proptest = "1.7"
 
 [features]
 slow-tests = []


### PR DESCRIPTION
@b-wagn Here is a proposition of some proptest with roundtrip to validate both our mappings. Let me know what you think about this.