### PR TITLE
Implement sparse Merkle Tree

### DIFF
--- a/benches/benchmark_poseidon.rs
+++ b/benches/benchmark_poseidon.rs
@@ -51,13 +51,13 @@ pub fn benchmark_signature_scheme<S: SignatureScheme>(c: &mut Criterion, descrip
     group.bench_function(format!("- gen"), |b| {
         b.iter(|| {
             // Benchmark key generation
-            let _ = S::gen(black_box(&mut rng));
+            let _ = S::gen(black_box(&mut rng), 0, S::LIFETIME as usize);
         });
     });
 
     group.sample_size(100);
 
-    let (pk, sk) = S::gen(&mut rng);
+    let (pk, sk) = S::gen(&mut rng, 0, S::LIFETIME as usize);
 
     group.bench_function(format!("- sign"), |b| {
         b.iter(|| {

--- a/benches/benchmark_poseidon_top_level.rs
+++ b/benches/benchmark_poseidon_top_level.rs
@@ -29,13 +29,13 @@ pub fn benchmark_signature_scheme<S: SignatureScheme>(c: &mut Criterion, descrip
     group.bench_function(format!("- gen"), |b| {
         b.iter(|| {
             // Benchmark key generation
-            let _ = S::gen(black_box(&mut rng));
+            let _ = S::gen(black_box(&mut rng), 0, S::LIFETIME as usize);
         });
     });
 
     group.sample_size(100);
 
-    let (pk, sk) = S::gen(&mut rng);
+    let (pk, sk) = S::gen(&mut rng, 0, S::LIFETIME as usize);
 
     group.bench_function(format!("- sign"), |b| {
         b.iter(|| {

--- a/benches/benchmark_sha.rs
+++ b/benches/benchmark_sha.rs
@@ -51,13 +51,13 @@ pub fn benchmark_signature_scheme<S: SignatureScheme>(c: &mut Criterion, descrip
     group.bench_function(format!("- gen"), |b| {
         b.iter(|| {
             // Benchmark key generation
-            let _ = S::gen(black_box(&mut rng));
+            let _ = S::gen(black_box(&mut rng), 0, S::LIFETIME as usize);
         });
     });
 
     group.sample_size(100);
 
-    let (pk, sk) = S::gen(&mut rng);
+    let (pk, sk) = S::gen(&mut rng, 0, S::LIFETIME as usize);
 
     group.bench_function(format!("- sign"), |b| {
         b.iter(|| {

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -25,7 +25,7 @@ fn measure_time<T: SignatureScheme, R: Rng>(description: &str, rng: &mut R) {
     // key gen
 
     let start = Instant::now();
-    let (_pk, _sk) = T::gen(rng);
+    let (_pk, _sk) = T::gen(rng, 0, T::LIFETIME as usize);
     let duration = start.elapsed();
     println!("{} - Gen: {:?}", description, duration);
 }

--- a/src/symmetric/tweak_hash_tree.rs
+++ b/src/symmetric/tweak_hash_tree.rs
@@ -38,13 +38,14 @@ pub struct HashTreeOpening<TH: TweakableHash> {
 }
 
 /// Helper function. Computes a padded layer from the meaningful entries of the layer.
-/// These meaningful entries are assumed to range from start_index to end_index (both inclusive).
+/// These meaningful entries are assumed to range from start_index to start_index + nodes.len() - 1 (both inclusive).
 fn get_padded_layer<R: Rng, TH: TweakableHash>(
     rng: &mut R,
     nodes: Vec<TH::Domain>,
     start_index: usize,
-    end_index: usize,
 ) -> HashTreeLayer<TH> {
+    let end_index = start_index + nodes.len() - 1;
+
     let mut nodes_with_padding = vec![];
 
     // padding in front if start_index is not even
@@ -104,8 +105,7 @@ where
         let mut layers: Vec<HashTreeLayer<TH>> = Vec::with_capacity(depth + 1);
 
         // start with the leaf layer, padded accordingly
-        let end_index = start_index + leafs_hashes.len() - 1;
-        layers.push(get_padded_layer(rng, leafs_hashes, start_index, end_index));
+        layers.push(get_padded_layer(rng, leafs_hashes, start_index));
 
         // now, build the tree layer by layer
         for level in 0..depth {
@@ -130,11 +130,8 @@ where
                 })
                 .collect();
 
-            // assert!(layers[level].start_index % 2 == 0);
-            // assert!((layers[level].start_index + layers[level].nodes.len() - 1) % 2 == 1);
             let start_index = layers[level].start_index / 2;
-            let end_index = (layers[level].start_index + layers[level].nodes.len()) / 2 - 1;
-            layers.push(get_padded_layer(rng, parents, start_index, end_index));
+            layers.push(get_padded_layer(rng, parents, start_index));
         }
         HashTree { depth, layers }
     }

--- a/src/symmetric/tweak_hash_tree.rs
+++ b/src/symmetric/tweak_hash_tree.rs
@@ -72,7 +72,7 @@ impl<TH> HashTree<TH>
 where
     TH: TweakableHash,
 {
-    /// Function to compute a hash-tree given the leafs hashes as input.
+    /// Function to compute a hash-tree given the leaf hashes as input.
     /// The tree will have the given depth, which bounds the number of leafs.
     /// It can have at most `1 << depth` many leafs. It has `depth + 1` layers.
     ///

--- a/src/symmetric/tweak_hash_tree.rs
+++ b/src/symmetric/tweak_hash_tree.rs
@@ -1,57 +1,142 @@
 use crate::symmetric::tweak_hash::TweakableHash;
+use rand::Rng;
 use rayon::prelude::*;
 
-/// Hash-Tree based on a tweakable hash function
+/// A single layer of a sparse Hash-Tree
+/// based on tweakable hash function
+struct HashTreeLayer<TH: TweakableHash> {
+    start_index: usize,
+    nodes: Vec<TH::Domain>,
+}
+
+/// Sparse Hash-Tree based on a tweakable hash function.
 /// We consider hash trees in which each leaf is first
 /// hashed individually.
+///
+/// The tree can be sparse in the following sense:
+/// There is a contiguous range of leafs that exist,
+/// and the tree is built on top of that.
+///
+/// For instance, we may consider a tree of depth 32,
+/// but only 2^{26} leafs really exist.
 pub struct HashTree<TH: TweakableHash> {
+    /// Depth of the tree. The tree can have at most
+    /// 1 << depth many leafs. It has depth + 1 many layers
+    depth: usize,
     /// Layers of the hash tree, starting with the
     /// bottom layer. The leafs are not included: the
     /// bottom layer is the list of hashes of all leafs
-    layers: Vec<Vec<TH::Domain>>,
+    layers: Vec<HashTreeLayer<TH>>,
+}
+
+/// Opening in a hash-tree: a co-path, without the leaf
+pub struct HashTreeOpening<TH: TweakableHash> {
+    /// The co-path needed to verify
+    /// If the tree has depth h, i.e, 2^h leafs
+    /// the co-path should have size D
+    co_path: Vec<TH::Domain>,
+}
+
+/// Helper function. Computes a padded layer from the meaningful entries of the layer.
+/// These meaningful entries are assumed to range from start_index to end_index (both inclusive).
+fn get_padded_layer<R: Rng, TH: TweakableHash>(
+    rng: &mut R,
+    nodes: Vec<TH::Domain>,
+    start_index: usize,
+    end_index: usize,
+) -> HashTreeLayer<TH> {
+    let mut nodes_with_padding = vec![];
+
+    // padding in front if start_index is not even
+    if start_index % 2 == 1 {
+        nodes_with_padding.push(TH::rand_domain(rng));
+    }
+    let actual_start_index = start_index - (start_index % 2);
+
+    // now add the actual content
+    nodes_with_padding.extend(nodes);
+
+    // add padding if end_index is not odd
+    if end_index % 2 == 0 {
+        nodes_with_padding.push(TH::rand_domain(rng));
+    }
+
+    HashTreeLayer {
+        start_index: actual_start_index,
+        nodes: nodes_with_padding,
+    }
 }
 
 impl<TH> HashTree<TH>
 where
     TH: TweakableHash,
 {
-    /// Function to compute a hash-tree given the leaf hashes as input.
-    /// The number of leaf hashes must be a power of two.
-    pub fn new(parameter: &TH::Parameter, leafs_hashes: Vec<TH::Domain>) -> Self {
+    /// Function to compute a hash-tree given the leafs hashes as input.
+    /// The tree will have the given depth, which bounds the number of leafs.
+    /// It can have at most `1 << depth` many leafs. It has `depth + 1` layers.
+    ///
+    /// The leafs start at the given start index, namely, the leafs that exist
+    /// are leafs `start, start + 1, ... start + leafs_hashes.len() - 1`
+    ///
+    /// Caller must ensure that there is enough space for the leaf hashes, i.e.,
+    /// `start_index + leaf_hashes.len() <= 1 << depth`
+    ///
+    pub fn new<R: Rng>(
+        rng: &mut R,
+        depth: usize,
+        start_index: usize,
+        parameter: &TH::Parameter,
+        leafs_hashes: Vec<TH::Domain>,
+    ) -> Self {
         // check that number of leafs is a power of two
         assert!(
-            leafs_hashes.len().is_power_of_two(),
-            "Hash-Tree build_tree: Number of leafs should be power of two"
+            start_index + leafs_hashes.len() <= 1 << depth,
+            "Hash-Tree new: Not enough space for leafs. Consider changing start_index or number of leaf hashes"
         );
 
-        let mut layer_size = leafs_hashes.len();
-        let mut layers: Vec<Vec<TH::Domain>> = Vec::with_capacity(layer_size.ilog2() as usize + 1);
+        // we build the tree from the leaf layer to the root,
+        // while building the tree, we ensure that the following two invariants hold via appropriate padding:
+        // 1. the layer starts at an even index, i.e., a left child
+        // 2. the layer ends at an odd index, i.e., a right child (does not hold for the root layer)
+        // In this way, we can ensure that we can always hash two siblings to get their parent
+        // The padding is ensured using the helper function `get_padded_layer`.
 
-        // the bottom layer contains the individual hashes of all leafs
-        layers.push(leafs_hashes);
+        let mut layers: Vec<HashTreeLayer<TH>> = Vec::with_capacity(depth + 1);
 
-        // now, we build each layer by hashing pairs in the previous layer
-        let mut level: u8 = 1;
-        while layer_size >= 2 {
-            // this new layer will have half the size
-            layer_size /= 2;
-            // parallelize the two to one compressions
-            layers.push(
-                (0..layer_size)
-                    .into_par_iter()
-                    .map(|i| {
-                        let left_idx = 2 * i;
-                        let right_idx = 2 * i + 1;
-                        let tweak = TH::tree_tweak(level, i as u32);
-                        let children = &layers[(level - 1) as usize][left_idx..=right_idx];
-                        TH::apply(parameter, &tweak, children)
-                    })
-                    .collect(),
-            );
-            level += 1;
+        // start with the leaf layer, padded accordingly
+        let end_index = start_index + leafs_hashes.len() - 1;
+        layers.push(get_padded_layer(rng, leafs_hashes, start_index, end_index));
+
+        // now, build the tree layer by layer
+        for level in 0..depth {
+            // build layer `level + 1` from layer `level`
+
+            // for that, we first build the parents of the previous layer and then
+            // add a padding if needed. We build the parents in parallel.
+            // assert!(layers[level].nodes.len()% 2 == 0);
+            let parents: Vec<_> = layers[level]
+                .nodes
+                .par_chunks(2)
+                .enumerate()
+                .map(|(i, children)| {
+                    assert!(
+                        children.len() == 2,
+                        "Unpaired children, padding logic broken"
+                    );
+                    let position_of_left_child = layers[level].start_index + 2 * i;
+                    let parent_pos = position_of_left_child / 2;
+                    let tweak = TH::tree_tweak((level + 1) as u8, parent_pos as u32);
+                    TH::apply(parameter, &tweak, children)
+                })
+                .collect();
+
+            // assert!(layers[level].start_index % 2 == 0);
+            // assert!((layers[level].start_index + layers[level].nodes.len() - 1) % 2 == 1);
+            let start_index = layers[level].start_index / 2;
+            let end_index = (layers[level].start_index + layers[level].nodes.len()) / 2 - 1;
+            layers.push(get_padded_layer(rng, parents, start_index, end_index));
         }
-
-        Self { layers }
+        HashTree { depth, layers }
     }
 
     /// Function to get a root from a tree. The tree must have at least one layer.
@@ -59,7 +144,8 @@ where
     pub fn root(&self) -> TH::Domain {
         self.layers
             .last()
-            .expect("Hash-Tree must have at least one layer")[0]
+            .expect("Hash-Tree must have at least one layer")
+            .nodes[0]
     }
 
     /// Function to compute the Merkle authentication path
@@ -70,29 +156,28 @@ where
     pub fn path(&self, position: u32) -> HashTreeOpening<TH> {
         assert!(
             !self.layers.is_empty(),
-            "Hash-Tree hash tree path: Need at least one layer"
+            "Hash-Tree path: Need at least one layer"
         );
         assert!(
-            (position as u64) < (self.layers[0].len() as u64),
-            "Hash-Tree hash tree path: Invalid position"
+            (position as u64) >= (self.layers[0].start_index as u64),
+            "Hash-Tree path: Invalid position, position before start index"
         );
-
-        let depth = self.layers.len() - 1;
-
         assert!(
-            depth <= 64,
-            "Hash-Tree hash tree path: Tree depth must be at most 64"
+            (position as u64)
+                < (self.layers[0].start_index as u64 + self.layers[0].nodes.len() as u64),
+            "Hash-Tree path: Invalid position, position too large"
         );
 
         // in our co-path, we will have one node per layer
         // except the final layer (which is just the root)
-        let mut co_path = Vec::with_capacity(depth);
+        let mut co_path = Vec::with_capacity(self.depth);
         let mut current_position = position;
-        for l in 0..depth {
+        for l in 0..self.depth {
             // position of the sibling that we want to include
             let sibling_position = current_position ^ 0x01;
+            let sibling_position_in_vec = sibling_position - self.layers[l].start_index as u32;
             // add to the co-path
-            let sibling = self.layers[l][sibling_position as usize];
+            let sibling = self.layers[l].nodes[sibling_position_in_vec as usize];
             co_path.push(sibling);
             // new position in next layer
             current_position >>= 1;
@@ -100,14 +185,6 @@ where
 
         HashTreeOpening { co_path }
     }
-}
-
-/// Opening in a hash-tree: a co-path, without the leaf
-pub struct HashTreeOpening<TH: TweakableHash> {
-    /// The co-path needed to verify
-    /// If the tree has depth h, i.e, 2^h leafs
-    /// the co-path should have size D
-    co_path: Vec<TH::Domain>,
 }
 
 /// Function to verify an Merkle authentication path
@@ -130,13 +207,13 @@ pub fn hash_tree_verify<TH: TweakableHash>(
     let num_leafs: u64 = 1 << depth;
 
     assert!(
-        depth <= 64,
-        "Hash-Tree hash tree verify: Tree depth must be at most 64"
+        depth <= 32,
+        "Hash-Tree verify: Tree depth must be at most 32"
     );
 
     assert!(
         (position as u64) < num_leafs,
-        "Hash-Tree hash tree verify: Position and Path Length not compatible"
+        "Hash-Tree verify: Position and Path Length not compatible"
     );
 
     // first hash the leaf to get the node in the bottom layer
@@ -179,17 +256,17 @@ mod tests {
 
     type TestTH = ShaTweak128192;
 
-    #[test]
-    fn test_commit_open_verify() {
+    /// We test that the following honest procedure succeeds:
+    /// (1) build the Merkle tree to get the root,
+    /// (2) build an authentication path for the leaf,
+    /// (3) verify the authentication path with respect to leaf and root
+    fn test_commit_open_helper(
+        num_leafs: usize,
+        depth: usize,
+        start_index: usize,
+        leaf_len: usize,
+    ) {
         let mut rng = thread_rng();
-        let num_leafs = 1024;
-        let leaf_len = 3;
-
-        // We test that the following honest procedure succeeds:
-        // (1) build the Merkle tree to get the root,
-        // (2) build an authentication path for the leaf,
-        // (3) verify the authentication path with respect to leaf and root
-
         // sample a random parameter and leafs
         let parameter = TestTH::rand_parameter(&mut rng);
 
@@ -205,22 +282,80 @@ mod tests {
         let leafs_hashes: Vec<_> = leafs
             .iter()
             .enumerate()
-            .map(|(i, v)| TestTH::apply(&parameter, &TestTH::tree_tweak(0, i as u32), v.as_slice()))
+            .map(|(i, v)| {
+                TestTH::apply(
+                    &parameter,
+                    &TestTH::tree_tweak(0, (i + start_index) as u32),
+                    v.as_slice(),
+                )
+            })
             .collect();
 
         // Build the hash tree using the random parameter and leaves
-        let tree = HashTree::<TestTH>::new(&parameter, leafs_hashes);
+        let tree = HashTree::<TestTH>::new(&mut rng, depth, start_index, &parameter, leafs_hashes);
 
         // now compute a commitment, i.e., Merkle root
         let root = tree.root();
 
         // now check that opening and verification works as expected
-        for position in 0..num_leafs {
+        for offset in 0..num_leafs {
+            // calculate the position
+            let position = start_index as u32 + offset as u32;
             // first get the opening
             let path = tree.path(position);
             // now assert that it verifies
-            let leaf = leafs[position as usize].as_slice();
+            let leaf = leafs[offset].as_slice();
             assert!(hash_tree_verify(&parameter, &root, position, leaf, &path));
         }
+    }
+
+    #[test]
+    fn test_commit_open_verify_full_tree() {
+        let num_leafs = 1024;
+        let depth = 10;
+        let start_index: usize = 0;
+        let leaf_len = 3;
+
+        test_commit_open_helper(num_leafs, depth, start_index, leaf_len);
+    }
+
+    #[test]
+    fn test_commit_open_verify_half_tree_left() {
+        let num_leafs = 512;
+        let depth = 10;
+        let start_index: usize = 0;
+        let leaf_len = 5;
+
+        test_commit_open_helper(num_leafs, depth, start_index, leaf_len);
+    }
+
+    #[test]
+    fn test_commit_open_verify_half_tree_right_large() {
+        let num_leafs = 512;
+        let depth = 10;
+        let start_index: usize = 512;
+        let leaf_len = 10;
+
+        test_commit_open_helper(num_leafs, depth, start_index, leaf_len);
+    }
+
+    #[test]
+    fn test_commit_open_verify_half_tree_right_small() {
+        let num_leafs = 2;
+        let depth = 2;
+        let start_index: usize = 2;
+        let leaf_len = 6;
+
+        test_commit_open_helper(num_leafs, depth, start_index, leaf_len);
+    }
+
+    #[test]
+    fn test_commit_open_verify_sparse_non_aligned() {
+        let num_leafs = 213;
+        let depth = 10;
+        let start_index: usize = 217;
+        let leaf_len = 3;
+
+        test_commit_open_helper(num_leafs, depth, start_index, leaf_len);
     }
 }


### PR DESCRIPTION
This PR changes the Merkle tree to support sparse settings, where only a contiguous section of leafs actually exists.  
This enables generating a tree of depth 32 without generating the entire tree.

*Why is this useful?* It enables to use the signature scheme with a predefined *maximum lifetime* of say 2^32, but
at the same time allows parties to decide not to have such a large lifetime (e.g., if they want smaller key gen time).

