### PR TITLE
hypercube: add proptest for map vertex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ dashmap = "6.1.0"
 
 [dev-dependencies]
 criterion = "0.5"
+proptest = "1.7"
 
 [features]
 slow-tests = []

--- a/src/hypercube.rs
+++ b/src/hypercube.rs
@@ -250,6 +250,7 @@ mod tests {
     use num_traits::FromPrimitive;
     use num_traits::ToPrimitive;
     use num_traits::Zero;
+    use proptest::prelude::*;
     use std::sync::Mutex;
 
     // Reference implementation for testing purposes
@@ -491,5 +492,46 @@ mod tests {
         let (d4, rem4) = hypercube_find_layer(w, v, BigUint::from(8u32));
         assert_eq!(d4, 4);
         assert_eq!(rem4, BigUint::zero());
+    }
+
+    proptest! {
+        #[test]
+        fn prop_map_vertex_roundtrip(
+            w in 2usize..8,
+            v in 1usize..16,
+            x in 0u64..100_000,
+        ) {
+            // Compute the total number of vertices in the hypercube [0, w-1]^v
+            let total_size = BigUint::from(w).pow(v as u32);
+
+            // Convert the sampled integer x to BigUint
+            let x_big = BigUint::from(x);
+
+            // Skip values that exceed the total number of vertices in the hypercube
+            prop_assume!(x_big < total_size);
+
+            // Given a global index x, determine which layer it belongs to
+            // and its offset within that layer.
+            let (d, rem) = hypercube_find_layer(w, v, x_big.clone());
+
+            // Convert the offset `rem` in layer `d` to an actual vertex in [0, w-1]^v.
+            let a = map_to_vertex(w, v, d, rem.clone());
+
+            // Check that a lies in layer d
+            let sum: usize = a.iter().map(|&ai| ai as usize).sum();
+            prop_assert_eq!((w - 1) * v - sum, d);
+
+            // Convert the vertex back to its local index in layer `d`.
+            let y = map_to_integer(w, v, d, &a);
+
+            // Double-check by mapping y back to the same vertex.
+            let b = map_to_vertex(w, v, d, y.clone());
+
+            // The index returned by `map_to_integer` should equal the original remainder.
+            prop_assert_eq!(rem, y);
+
+            // The vertex should be unchanged after round-tripping.
+            prop_assert_eq!(a, b);
+        }
     }
 }


### PR DESCRIPTION
Replacement for https://github.com/b-wagn/hash-sig/pull/45