### PR TITLE
Add serde support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ num-bigint = "0.4.6"
 rayon = "1.10.0"
 num-traits = "0.2.19"
 dashmap = "6.1.0"
+serde = { version = "1.0", features = ["derive", "alloc"] }
 
 p3-field = { git = "https://github.com/Plonky3/Plonky3.git", rev = "d0c4a36" }
 p3-baby-bear = { git = "https://github.com/Plonky3/Plonky3.git", rev = "d0c4a36" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ p3-symmetric = { git = "https://github.com/Plonky3/Plonky3.git", rev = "d0c4a36"
 [dev-dependencies]
 criterion = "0.5"
 proptest = "1.7"
+bincode = { version = "2.0.1", features = ["serde"] }
 
 [features]
 slow-tests = []

--- a/src/inc_encoding.rs
+++ b/src/inc_encoding.rs
@@ -1,4 +1,5 @@
 use rand::Rng;
+use serde::{de::DeserializeOwned, Serialize};
 
 use crate::MESSAGE_LENGTH;
 
@@ -18,8 +19,8 @@ pub type EncodingError = ();
 /// x = (x_1,..,x_k) and x' = (x'_1,..,x'_k) we have
 /// x_i > x_i' for all i = 1,...,k.
 pub trait IncomparableEncoding {
-    type Parameter;
-    type Randomness;
+    type Parameter: Serialize + DeserializeOwned;
+    type Randomness: Serialize + DeserializeOwned;
 
     /// number of entries in a codeword
     const DIMENSION: usize;

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -62,6 +62,8 @@ pub mod generalized_xmss;
 
 #[cfg(test)]
 mod test_templates {
+    use serde::{de::DeserializeOwned, Serialize};
+
     use super::*;
 
     /// Generic test for any implementation of the `SignatureScheme` trait.
@@ -99,5 +101,19 @@ mod test_templates {
             "Signature verification failed. . Epoch was {:?}",
             epoch
         );
+
+        test_bincode_round_trip_consistency(&pk);
+        test_bincode_round_trip_consistency(&sk);
+        test_bincode_round_trip_consistency(&signature);
+    }
+
+    fn test_bincode_round_trip_consistency<T: Serialize + DeserializeOwned>(ori: &T) {
+        use bincode::serde::{decode_from_slice, encode_to_vec};
+        let config = bincode::config::standard();
+        let bytes_ori = encode_to_vec(ori, config).expect("Bincode encode should not fail");
+        let (dec, _): (T, _) =
+            decode_from_slice(&bytes_ori, config).expect("Bincode decode should not fail");
+        let bytes_dec = encode_to_vec(dec, config).expect("Bincode encode should not fail");
+        assert_eq!(bytes_ori, bytes_dec, "Serde consistency check failed");
     }
 }

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -1,4 +1,5 @@
 use rand::Rng;
+use serde::{de::DeserializeOwned, Serialize};
 
 use crate::MESSAGE_LENGTH;
 
@@ -13,9 +14,9 @@ pub enum SigningError {
 /// We sign messages with respect to epochs.
 /// We assume each we sign for each epoch only once.
 pub trait SignatureScheme {
-    type PublicKey;
-    type SecretKey;
-    type Signature;
+    type PublicKey: Serialize + DeserializeOwned;
+    type SecretKey: Serialize + DeserializeOwned;
+    type Signature: Serialize + DeserializeOwned;
 
     /// number of epochs that are supported
     /// with one key. Must be a power of two.

--- a/src/signature/generalized_xmss.rs
+++ b/src/signature/generalized_xmss.rs
@@ -1,5 +1,6 @@
 use rand::Rng;
 use rayon::prelude::*;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     inc_encoding::IncomparableEncoding,
@@ -33,6 +34,8 @@ pub struct GeneralizedXMSSSignatureScheme<
 
 /// Signature for GeneralizedXMSSSignatureScheme
 /// It contains a Merkle authentication path, encoding randomness, and a list of hashes
+#[derive(Serialize, Deserialize)]
+#[serde(bound = "")]
 pub struct GeneralizedXMSSSignature<IE: IncomparableEncoding, TH: TweakableHash> {
     path: HashTreeOpening<TH>,
     rho: IE::Randomness,
@@ -41,6 +44,7 @@ pub struct GeneralizedXMSSSignature<IE: IncomparableEncoding, TH: TweakableHash>
 
 /// Public key for GeneralizedXMSSSignatureScheme
 /// It contains a Merkle root and a parameter for the tweakable hash
+#[derive(Serialize, Deserialize)]
 pub struct GeneralizedXMSSPublicKey<TH: TweakableHash> {
     root: TH::Domain,
     parameter: TH::Parameter,
@@ -51,6 +55,8 @@ pub struct GeneralizedXMSSPublicKey<TH: TweakableHash> {
 ///
 /// Note: one may choose to regenerate the tree on the fly, but this
 /// would be costly for signatures.
+#[derive(Serialize, Deserialize)]
+#[serde(bound = "")]
 pub struct GeneralizedXMSSSecretKey<PRF: Pseudorandom, TH: TweakableHash> {
     prf_key: PRF::Key,
     tree: HashTree<TH>,

--- a/src/symmetric/message_hash.rs
+++ b/src/symmetric/message_hash.rs
@@ -1,4 +1,5 @@
 use rand::Rng;
+use serde::{de::DeserializeOwned, Serialize};
 
 use crate::MESSAGE_LENGTH;
 
@@ -11,8 +12,8 @@ use crate::MESSAGE_LENGTH;
 ///
 /// Note that BASE must be at most 2^8, as we encode chunks as u8.
 pub trait MessageHash {
-    type Parameter: Clone + Sized;
-    type Randomness;
+    type Parameter: Clone + Sized + Serialize + DeserializeOwned;
+    type Randomness: Serialize + DeserializeOwned;
 
     /// number of entries in a hash
     const DIMENSION: usize;

--- a/src/symmetric/message_hash/poseidon.rs
+++ b/src/symmetric/message_hash/poseidon.rs
@@ -4,6 +4,7 @@ use p3_baby_bear::BabyBear;
 use p3_field::PrimeCharacteristicRing;
 use p3_field::PrimeField;
 use p3_field::PrimeField64;
+use serde::{de::DeserializeOwned, Serialize};
 
 use super::MessageHash;
 use crate::symmetric::tweak_hash::poseidon::poseidon_compress;
@@ -98,6 +99,9 @@ impl<
         TWEAK_LEN_FE,
         MSG_LEN_FE,
     >
+where
+    [F; PARAMETER_LEN]: Serialize + DeserializeOwned,
+    [F; RAND_LEN_FE]: Serialize + DeserializeOwned,
 {
     type Parameter = [F; PARAMETER_LEN];
 

--- a/src/symmetric/message_hash/sha.rs
+++ b/src/symmetric/message_hash/sha.rs
@@ -1,6 +1,7 @@
 use crate::{
     symmetric::message_hash::bytes_to_chunks, MESSAGE_LENGTH, TWEAK_SEPARATOR_FOR_MESSAGE_HASH,
 };
+use serde::{de::DeserializeOwned, Serialize};
 
 use super::MessageHash;
 
@@ -24,6 +25,9 @@ impl<
         const NUM_CHUNKS: usize,
         const CHUNK_SIZE: usize,
     > MessageHash for ShaMessageHash<PARAMETER_LEN, RAND_LEN, NUM_CHUNKS, CHUNK_SIZE>
+where
+    [u8; PARAMETER_LEN]: Serialize + DeserializeOwned,
+    [u8; RAND_LEN]: Serialize + DeserializeOwned,
 {
     type Parameter = [u8; PARAMETER_LEN];
 

--- a/src/symmetric/message_hash/top_level_poseidon.rs
+++ b/src/symmetric/message_hash/top_level_poseidon.rs
@@ -4,6 +4,7 @@ use p3_baby_bear::BabyBear;
 use p3_field::PrimeCharacteristicRing;
 use p3_field::PrimeField;
 use p3_field::PrimeField64;
+use serde::{de::DeserializeOwned, Serialize};
 
 use super::poseidon::encode_epoch;
 use super::poseidon::encode_message;
@@ -115,6 +116,9 @@ impl<
         PARAMETER_LEN,
         RAND_LEN,
     >
+where
+    [F; PARAMETER_LEN]: Serialize + DeserializeOwned,
+    [F; RAND_LEN]: Serialize + DeserializeOwned,
 {
     type Parameter = [F; PARAMETER_LEN];
 

--- a/src/symmetric/prf.rs
+++ b/src/symmetric/prf.rs
@@ -1,8 +1,9 @@
 use rand::Rng;
+use serde::{de::DeserializeOwned, Serialize};
 
 /// Trait to model a pseudorandom function
 pub trait Pseudorandom {
-    type Key: Send + Sync;
+    type Key: Send + Sync + Serialize + DeserializeOwned;
     type Output;
 
     /// Sample a random domain element

--- a/src/symmetric/prf/sha.rs
+++ b/src/symmetric/prf/sha.rs
@@ -1,4 +1,5 @@
 use super::Pseudorandom;
+use serde::{de::DeserializeOwned, Serialize};
 use sha3::{Digest, Sha3_256};
 
 const KEY_LENGTH: usize = 32; // 32 bytes
@@ -10,7 +11,10 @@ const PRF_DOMAIN_SEP: [u8; 16] = [
 // Output Length must be at most 32 bytes
 pub struct ShaPRF<const OUTPUT_LENGTH: usize>;
 
-impl<const OUTPUT_LENGTH: usize> Pseudorandom for ShaPRF<OUTPUT_LENGTH> {
+impl<const OUTPUT_LENGTH: usize> Pseudorandom for ShaPRF<OUTPUT_LENGTH>
+where
+    [u8; OUTPUT_LENGTH]: Serialize + DeserializeOwned,
+{
     type Key = [u8; KEY_LENGTH];
     type Output = [u8; OUTPUT_LENGTH];
 

--- a/src/symmetric/prf/shake_to_field.rs
+++ b/src/symmetric/prf/shake_to_field.rs
@@ -2,6 +2,7 @@ use super::Pseudorandom;
 use p3_baby_bear::BabyBear;
 use p3_field::PrimeCharacteristicRing;
 use p3_field::PrimeField64;
+use serde::{de::DeserializeOwned, Serialize};
 use sha3::{
     digest::{ExtendableOutput, Update, XofReader},
     Shake128,
@@ -24,7 +25,10 @@ const PRF_DOMAIN_SEP: [u8; 16] = [
 /// It outputs OUTPUT_LENGTH_FE many field elements.
 pub struct ShakePRFtoF<const OUTPUT_LENGTH_FE: usize>;
 
-impl<const OUTPUT_LENGTH_FE: usize> Pseudorandom for ShakePRFtoF<OUTPUT_LENGTH_FE> {
+impl<const OUTPUT_LENGTH_FE: usize> Pseudorandom for ShakePRFtoF<OUTPUT_LENGTH_FE>
+where
+    [F; OUTPUT_LENGTH_FE]: Serialize + DeserializeOwned,
+{
     type Key = [u8; KEY_LENGTH];
     type Output = [F; OUTPUT_LENGTH_FE];
 

--- a/src/symmetric/tweak_hash.rs
+++ b/src/symmetric/tweak_hash.rs
@@ -1,4 +1,5 @@
 use rand::Rng;
+use serde::{de::DeserializeOwned, Serialize};
 
 /// Trait to model a tweakable hash function.
 /// Such a function takes a public parameter, a tweak, and a
@@ -13,9 +14,9 @@ use rand::Rng;
 /// to obtain distinct tweaks for applications in chains and
 /// applications in Merkle trees.
 pub trait TweakableHash {
-    type Parameter: Copy + Sized + Send + Sync;
+    type Parameter: Copy + Sized + Send + Sync + Serialize + DeserializeOwned;
     type Tweak;
-    type Domain: Copy + PartialEq + Sized + Send + Sync;
+    type Domain: Copy + PartialEq + Sized + Send + Sync + Serialize + DeserializeOwned;
 
     /// Generates a random public parameter.
     fn rand_parameter<R: Rng>(rng: &mut R) -> Self::Parameter;

--- a/src/symmetric/tweak_hash/poseidon.rs
+++ b/src/symmetric/tweak_hash/poseidon.rs
@@ -4,6 +4,7 @@ use p3_baby_bear::BabyBear;
 use p3_field::PrimeCharacteristicRing;
 use p3_field::PrimeField64;
 use p3_symmetric::Permutation;
+use serde::{de::DeserializeOwned, Serialize};
 
 use crate::TWEAK_SEPARATOR_FOR_CHAIN_HASH;
 use crate::TWEAK_SEPARATOR_FOR_TREE_HASH;
@@ -243,8 +244,10 @@ impl<
         const TWEAK_LEN: usize,
         const CAPACITY: usize,
         const NUM_CHUNKS: usize,
-    > TweakableHash
-    for PoseidonTweakHash<PARAMETER_LEN, HASH_LEN, TWEAK_LEN, CAPACITY, NUM_CHUNKS>
+    > TweakableHash for PoseidonTweakHash<PARAMETER_LEN, HASH_LEN, TWEAK_LEN, CAPACITY, NUM_CHUNKS>
+where
+    [F; PARAMETER_LEN]: Serialize + DeserializeOwned,
+    [F; HASH_LEN]: Serialize + DeserializeOwned,
 {
     type Parameter = [F; PARAMETER_LEN];
 

--- a/src/symmetric/tweak_hash/sha.rs
+++ b/src/symmetric/tweak_hash/sha.rs
@@ -1,3 +1,4 @@
+use serde::{de::DeserializeOwned, Serialize};
 use sha3::{Digest, Sha3_256};
 
 use crate::{TWEAK_SEPARATOR_FOR_CHAIN_HASH, TWEAK_SEPARATOR_FOR_TREE_HASH};
@@ -62,6 +63,9 @@ pub struct ShaTweakHash<const PARAMETER_LEN: usize, const HASH_LEN: usize>;
 
 impl<const PARAMETER_LEN: usize, const HASH_LEN: usize> TweakableHash
     for ShaTweakHash<PARAMETER_LEN, HASH_LEN>
+where
+    [u8; PARAMETER_LEN]: Serialize + DeserializeOwned,
+    [u8; HASH_LEN]: Serialize + DeserializeOwned,
 {
     type Parameter = [u8; PARAMETER_LEN];
 

--- a/src/symmetric/tweak_hash_tree.rs
+++ b/src/symmetric/tweak_hash_tree.rs
@@ -1,9 +1,12 @@
 use crate::symmetric::tweak_hash::TweakableHash;
 use rand::Rng;
 use rayon::prelude::*;
+use serde::{Deserialize, Serialize};
 
 /// A single layer of a sparse Hash-Tree
 /// based on tweakable hash function
+#[derive(Serialize, Deserialize)]
+#[serde(bound = "")]
 struct HashTreeLayer<TH: TweakableHash> {
     start_index: usize,
     nodes: Vec<TH::Domain>,
@@ -19,6 +22,8 @@ struct HashTreeLayer<TH: TweakableHash> {
 ///
 /// For instance, we may consider a tree of depth 32,
 /// but only 2^{26} leafs really exist.
+#[derive(Serialize, Deserialize)]
+#[serde(bound = "")]
 pub struct HashTree<TH: TweakableHash> {
     /// Depth of the tree. The tree can have at most
     /// 1 << depth many leafs. It has depth + 1 many layers
@@ -30,6 +35,8 @@ pub struct HashTree<TH: TweakableHash> {
 }
 
 /// Opening in a hash-tree: a co-path, without the leaf
+#[derive(Serialize, Deserialize)]
+#[serde(bound = "")]
 pub struct HashTreeOpening<TH: TweakableHash> {
     /// The co-path needed to verify
     /// If the tree has depth h, i.e, 2^h leafs


### PR DESCRIPTION
- Add trait bound to `SignatureScheme::PublicKey`, `SignatureScheme::SecretKey`, and `SignatureScheme::Signature`
- Derive serde for `GeneralizedXMSSSignatureScheme`'s keys and signature, and add necessary serde trait bound to underlying associated types
- Add a round-trip check for serde using `bincode`
