### PR TITLE
rust version: min 1.87

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "hashsig"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
+rust-version = "1.87"
 
 [lints.clippy]
 # all lints that are on by default (correctness, suspicious, style, complexity, perf)

--- a/benches/benchmark_poseidon.rs
+++ b/benches/benchmark_poseidon.rs
@@ -1,8 +1,10 @@
-use criterion::{black_box, Criterion, SamplingMode};
+use criterion::{Criterion, SamplingMode, black_box};
 use rand::Rng;
 
 use hashsig::{
+    MESSAGE_LENGTH,
     signature::{
+        SignatureScheme,
         generalized_xmss::instantiations_poseidon::{
             lifetime_2_to_the_18::{
                 target_sum::{
@@ -29,9 +31,7 @@ use hashsig::{
                 },
             },
         },
-        SignatureScheme,
     },
-    MESSAGE_LENGTH,
 };
 
 /// A template for benchmarking signature schemes (key gen, signing, verification)
@@ -51,13 +51,13 @@ pub fn benchmark_signature_scheme<S: SignatureScheme>(c: &mut Criterion, descrip
     group.bench_function("- gen", |b| {
         b.iter(|| {
             // Benchmark key generation
-            let _ = S::gen(black_box(&mut rng), 0, S::LIFETIME as usize);
+            let _ = S::random(black_box(&mut rng), 0, S::LIFETIME as usize);
         });
     });
 
     group.sample_size(100);
 
-    let (pk, sk) = S::gen(&mut rng, 0, S::LIFETIME as usize);
+    let (pk, sk) = S::random(&mut rng, 0, S::LIFETIME as usize);
 
     group.bench_function("- sign", |b| {
         b.iter(|| {

--- a/benches/benchmark_poseidon_top_level.rs
+++ b/benches/benchmark_poseidon_top_level.rs
@@ -1,10 +1,12 @@
 use std::cmp::min;
 
-use criterion::{black_box, Criterion, SamplingMode};
+use criterion::{Criterion, SamplingMode, black_box};
 use rand::Rng;
 
 use hashsig::{
+    MESSAGE_LENGTH,
     signature::{
+        SignatureScheme,
         generalized_xmss::instantiations_poseidon_top_level::{
             lifetime_2_to_the_18::SIGTopLevelTargetSumLifetime18Dim64Base8,
             lifetime_2_to_the_32::{
@@ -13,9 +15,7 @@ use hashsig::{
                 tradeoff::SIGTopLevelTargetSumLifetime32Dim48Base10,
             },
         },
-        SignatureScheme,
     },
-    MESSAGE_LENGTH,
 };
 
 /// We will benchmark with actual lifetime min(LIFETIME, 1 << MAX_LOG_ACTIVATION_DURATION)
@@ -42,13 +42,13 @@ pub fn benchmark_signature_scheme<S: SignatureScheme>(c: &mut Criterion, descrip
     group.bench_function("- gen", |b| {
         b.iter(|| {
             // Benchmark key generation
-            let _ = S::gen(black_box(&mut rng), 0, activation_duration);
+            let _ = S::random(black_box(&mut rng), 0, activation_duration);
         });
     });
 
     group.sample_size(100);
 
-    let (pk, sk) = S::gen(&mut rng, 0, activation_duration);
+    let (pk, sk) = S::random(&mut rng, 0, activation_duration);
 
     group.bench_function("- sign", |b| {
         b.iter(|| {
@@ -102,24 +102,32 @@ pub fn bench_function_poseidon_top_level(c: &mut Criterion) {
     // benchmarking lifetime 2^18
     benchmark_signature_scheme::<SIGTopLevelTargetSumLifetime18Dim64Base8>(
         c,
-        &format!("Top Level TS, Lifetime 2^18, Activation 2^{MAX_LOG_ACTIVATION_DURATION}, Dimension 64, Base 8")
+        &format!(
+            "Top Level TS, Lifetime 2^18, Activation 2^{MAX_LOG_ACTIVATION_DURATION}, Dimension 64, Base 8"
+        ),
     );
 
     // benchmarking lifetime 2^32 - hashing optimized
     benchmark_signature_scheme::<SIGTopLevelTargetSumLifetime32Dim64Base8>(
         c,
-        &format!("Top Level TS, Lifetime 2^32, Activation 2^{MAX_LOG_ACTIVATION_DURATION}, Dimension 64, Base 8 (Hashing Optimized)")
+        &format!(
+            "Top Level TS, Lifetime 2^32, Activation 2^{MAX_LOG_ACTIVATION_DURATION}, Dimension 64, Base 8 (Hashing Optimized)"
+        ),
     );
 
     // benchmarking lifetime 2^32 - trade-off
     benchmark_signature_scheme::<SIGTopLevelTargetSumLifetime32Dim48Base10>(
         c,
-        &format!("Top Level TS, Lifetime 2^32, Activation 2^{MAX_LOG_ACTIVATION_DURATION}, Dimension 48, Base 10 (Trade-off)")
+        &format!(
+            "Top Level TS, Lifetime 2^32, Activation 2^{MAX_LOG_ACTIVATION_DURATION}, Dimension 48, Base 10 (Trade-off)"
+        ),
     );
 
     // benchmarking lifetime 2^32 - size optimized
     benchmark_signature_scheme::<SIGTopLevelTargetSumLifetime32Dim32Base26>(
         c,
-        &format!("Top Level TS, Lifetime 2^32, Activation 2^{MAX_LOG_ACTIVATION_DURATION}, Dimension 32, Base 26 (Size Optimized)")
+        &format!(
+            "Top Level TS, Lifetime 2^32, Activation 2^{MAX_LOG_ACTIVATION_DURATION}, Dimension 32, Base 26 (Size Optimized)"
+        ),
     );
 }

--- a/benches/benchmark_sha.rs
+++ b/benches/benchmark_sha.rs
@@ -1,8 +1,10 @@
-use criterion::{black_box, Criterion, SamplingMode};
+use criterion::{Criterion, SamplingMode, black_box};
 use rand::Rng;
 
 use hashsig::{
+    MESSAGE_LENGTH,
     signature::{
+        SignatureScheme,
         generalized_xmss::instantiations_sha::{
             lifetime_2_to_the_18::{
                 target_sum::{
@@ -29,9 +31,7 @@ use hashsig::{
                 },
             },
         },
-        SignatureScheme,
     },
-    MESSAGE_LENGTH,
 };
 
 /// A template for benchmarking signature schemes (key gen, signing, verification)
@@ -51,13 +51,13 @@ pub fn benchmark_signature_scheme<S: SignatureScheme>(c: &mut Criterion, descrip
     group.bench_function("- gen", |b| {
         b.iter(|| {
             // Benchmark key generation
-            let _ = S::gen(black_box(&mut rng), 0, S::LIFETIME as usize);
+            let _ = S::random(black_box(&mut rng), 0, S::LIFETIME as usize);
         });
     });
 
     group.sample_size(100);
 
-    let (pk, sk) = S::gen(&mut rng, 0, S::LIFETIME as usize);
+    let (pk, sk) = S::random(&mut rng, 0, S::LIFETIME as usize);
 
     group.bench_function("- sign", |b| {
         b.iter(|| {

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -24,7 +24,7 @@ fn measure_time<T: SignatureScheme, R: Rng>(description: &str, rng: &mut R) {
     // key gen
 
     let start = Instant::now();
-    let (_pk, _sk) = T::gen(rng, 0, T::LIFETIME as usize);
+    let (_pk, _sk) = T::random(rng, 0, T::LIFETIME as usize);
     let duration = start.elapsed();
     println!("{description} - Gen: {duration:?}");
 }

--- a/src/hypercube.rs
+++ b/src/hypercube.rs
@@ -1,5 +1,5 @@
-use dashmap::mapref::one::Ref;
 use dashmap::DashMap;
+use dashmap::mapref::one::Ref;
 use num_bigint::BigUint;
 use num_traits::One;
 use num_traits::ToPrimitive;

--- a/src/inc_encoding.rs
+++ b/src/inc_encoding.rs
@@ -1,5 +1,5 @@
 use rand::Rng;
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 
 use crate::MESSAGE_LENGTH;
 

--- a/src/inc_encoding/basic_winternitz.rs
+++ b/src/inc_encoding/basic_winternitz.rs
@@ -1,6 +1,6 @@
 use crate::{
-    symmetric::message_hash::{bytes_to_chunks, MessageHash},
     MESSAGE_LENGTH,
+    symmetric::message_hash::{MessageHash, bytes_to_chunks},
 };
 
 use super::IncomparableEncoding;

--- a/src/inc_encoding/target_sum.rs
+++ b/src/inc_encoding/target_sum.rs
@@ -1,4 +1,4 @@
-use crate::{symmetric::message_hash::MessageHash, MESSAGE_LENGTH};
+use crate::{MESSAGE_LENGTH, symmetric::message_hash::MessageHash};
 
 use super::IncomparableEncoding;
 

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -1,5 +1,5 @@
 use rand::Rng;
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 
 use crate::MESSAGE_LENGTH;
 
@@ -29,7 +29,7 @@ pub trait SignatureScheme {
     ///
     /// The caller must ensure that this is a valid range, i.e., that
     /// `activation_epoch+num_active_epochs <= LIFETIME`.
-    fn gen<R: Rng>(
+    fn random<R: Rng>(
         rng: &mut R,
         activation_epoch: usize,
         num_active_epochs: usize,
@@ -62,7 +62,7 @@ pub mod generalized_xmss;
 
 #[cfg(test)]
 mod test_templates {
-    use serde::{de::DeserializeOwned, Serialize};
+    use serde::{Serialize, de::DeserializeOwned};
 
     use super::*;
 
@@ -77,7 +77,7 @@ mod test_templates {
         let mut rng = rand::rng();
 
         // Generate a key pair
-        let (pk, sk) = T::gen(&mut rng, activation_epoch, num_active_epochs);
+        let (pk, sk) = T::random(&mut rng, activation_epoch, num_active_epochs);
 
         // Sample random test message
         let message = rng.random();

--- a/src/signature/generalized_xmss.rs
+++ b/src/signature/generalized_xmss.rs
@@ -3,13 +3,13 @@ use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    MESSAGE_LENGTH,
     inc_encoding::IncomparableEncoding,
     symmetric::{
         prf::Pseudorandom,
-        tweak_hash::{chain, TweakableHash},
-        tweak_hash_tree::{hash_tree_verify, HashTree, HashTreeOpening},
+        tweak_hash::{TweakableHash, chain},
+        tweak_hash_tree::{HashTree, HashTreeOpening, hash_tree_verify},
     },
-    MESSAGE_LENGTH,
 };
 
 use super::{SignatureScheme, SigningError};
@@ -79,7 +79,7 @@ where
 
     const LIFETIME: u64 = 1 << LOG_LIFETIME;
 
-    fn gen<R: Rng>(
+    fn random<R: Rng>(
         rng: &mut R,
         activation_epoch: usize,
         num_active_epochs: usize,
@@ -103,7 +103,7 @@ where
         let parameter = TH::rand_parameter(rng);
 
         // we need a PRF key to generate our list of actual secret keys
-        let prf_key = PRF::gen(rng);
+        let prf_key = PRF::random(rng);
 
         // for each epoch, generate the secret key for the epoch, where
         // an epoch secret key is a list of domain elements derived from the
@@ -334,9 +334,9 @@ mod tests {
         signature::test_templates::test_signature_scheme_correctness,
         symmetric::{
             message_hash::{
+                MessageHash,
                 poseidon::PoseidonMessageHashW1,
                 sha::{ShaMessageHash, ShaMessageHash192x3},
-                MessageHash,
             },
             prf::{sha::ShaPRF, shake_to_field::ShakePRFtoF},
             tweak_hash::{poseidon::PoseidonTweakW1L5, sha::ShaTweak192192},

--- a/src/signature/generalized_xmss/instantiations_poseidon_top_level.rs
+++ b/src/signature/generalized_xmss/instantiations_poseidon_top_level.rs
@@ -50,8 +50,8 @@ pub mod lifetime_2_to_the_18 {
     mod test {
 
         use crate::signature::{
-            generalized_xmss::instantiations_poseidon_top_level::lifetime_2_to_the_18::SIGTopLevelTargetSumLifetime18Dim64Base8,
             SignatureScheme,
+            generalized_xmss::instantiations_poseidon_top_level::lifetime_2_to_the_18::SIGTopLevelTargetSumLifetime18Dim64Base8,
         };
 
         #[cfg(feature = "slow-tests")]

--- a/src/symmetric/message_hash.rs
+++ b/src/symmetric/message_hash.rs
@@ -1,5 +1,5 @@
 use rand::Rng;
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 
 use crate::MESSAGE_LENGTH;
 

--- a/src/symmetric/message_hash/poseidon.rs
+++ b/src/symmetric/message_hash/poseidon.rs
@@ -1,15 +1,15 @@
 use num_bigint::BigUint;
-use p3_baby_bear::default_babybear_poseidon2_24;
 use p3_baby_bear::BabyBear;
+use p3_baby_bear::default_babybear_poseidon2_24;
 use p3_field::PrimeCharacteristicRing;
 use p3_field::PrimeField;
 use p3_field::PrimeField64;
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 
 use super::MessageHash;
-use crate::symmetric::tweak_hash::poseidon::poseidon_compress;
 use crate::MESSAGE_LENGTH;
 use crate::TWEAK_SEPARATOR_FOR_MESSAGE_HASH;
+use crate::symmetric::tweak_hash::poseidon::poseidon_compress;
 
 type F = BabyBear;
 
@@ -82,14 +82,14 @@ pub struct PoseidonMessageHash<
 >;
 
 impl<
-        const PARAMETER_LEN: usize,
-        const RAND_LEN_FE: usize,
-        const HASH_LEN_FE: usize,
-        const DIMENSION: usize,
-        const BASE: usize,
-        const TWEAK_LEN_FE: usize,
-        const MSG_LEN_FE: usize,
-    > MessageHash
+    const PARAMETER_LEN: usize,
+    const RAND_LEN_FE: usize,
+    const HASH_LEN_FE: usize,
+    const DIMENSION: usize,
+    const BASE: usize,
+    const TWEAK_LEN_FE: usize,
+    const MSG_LEN_FE: usize,
+> MessageHash
     for PoseidonMessageHash<
         PARAMETER_LEN,
         RAND_LEN_FE,

--- a/src/symmetric/message_hash/sha.rs
+++ b/src/symmetric/message_hash/sha.rs
@@ -1,7 +1,7 @@
 use crate::{
-    symmetric::message_hash::bytes_to_chunks, MESSAGE_LENGTH, TWEAK_SEPARATOR_FOR_MESSAGE_HASH,
+    MESSAGE_LENGTH, TWEAK_SEPARATOR_FOR_MESSAGE_HASH, symmetric::message_hash::bytes_to_chunks,
 };
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 
 use super::MessageHash;
 
@@ -20,11 +20,11 @@ pub struct ShaMessageHash<
 >;
 
 impl<
-        const PARAMETER_LEN: usize,
-        const RAND_LEN: usize,
-        const NUM_CHUNKS: usize,
-        const CHUNK_SIZE: usize,
-    > MessageHash for ShaMessageHash<PARAMETER_LEN, RAND_LEN, NUM_CHUNKS, CHUNK_SIZE>
+    const PARAMETER_LEN: usize,
+    const RAND_LEN: usize,
+    const NUM_CHUNKS: usize,
+    const CHUNK_SIZE: usize,
+> MessageHash for ShaMessageHash<PARAMETER_LEN, RAND_LEN, NUM_CHUNKS, CHUNK_SIZE>
 where
     [u8; PARAMETER_LEN]: Serialize + DeserializeOwned,
     [u8; RAND_LEN]: Serialize + DeserializeOwned,

--- a/src/symmetric/message_hash/top_level_poseidon.rs
+++ b/src/symmetric/message_hash/top_level_poseidon.rs
@@ -1,19 +1,19 @@
 use num_bigint::BigUint;
-use p3_baby_bear::default_babybear_poseidon2_24;
 use p3_baby_bear::BabyBear;
+use p3_baby_bear::default_babybear_poseidon2_24;
 use p3_field::PrimeCharacteristicRing;
 use p3_field::PrimeField;
 use p3_field::PrimeField64;
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 
+use super::MessageHash;
 use super::poseidon::encode_epoch;
 use super::poseidon::encode_message;
-use super::MessageHash;
+use crate::MESSAGE_LENGTH;
 use crate::hypercube::hypercube_find_layer;
 use crate::hypercube::hypercube_part_size;
 use crate::hypercube::map_to_vertex;
 use crate::symmetric::tweak_hash::poseidon::poseidon_compress;
-use crate::MESSAGE_LENGTH;
 
 type F = BabyBear;
 
@@ -93,17 +93,17 @@ pub struct TopLevelPoseidonMessageHash<
 >;
 
 impl<
-        const POS_OUTPUT_LEN_PER_INV_FE: usize,
-        const POS_INVOCATIONS: usize,
-        const POS_OUTPUT_LEN_FE: usize,
-        const DIMENSION: usize,
-        const BASE: usize,
-        const FINAL_LAYER: usize,
-        const TWEAK_LEN_FE: usize,
-        const MSG_LEN_FE: usize,
-        const PARAMETER_LEN: usize,
-        const RAND_LEN: usize,
-    > MessageHash
+    const POS_OUTPUT_LEN_PER_INV_FE: usize,
+    const POS_INVOCATIONS: usize,
+    const POS_OUTPUT_LEN_FE: usize,
+    const DIMENSION: usize,
+    const BASE: usize,
+    const FINAL_LAYER: usize,
+    const TWEAK_LEN_FE: usize,
+    const MSG_LEN_FE: usize,
+    const PARAMETER_LEN: usize,
+    const RAND_LEN: usize,
+> MessageHash
     for TopLevelPoseidonMessageHash<
         POS_OUTPUT_LEN_PER_INV_FE,
         POS_INVOCATIONS,
@@ -245,7 +245,7 @@ mod tests {
     use rand::Rng;
 
     use crate::symmetric::message_hash::{
-        top_level_poseidon::TopLevelPoseidonMessageHash, MessageHash,
+        MessageHash, top_level_poseidon::TopLevelPoseidonMessageHash,
     };
 
     #[test]

--- a/src/symmetric/prf.rs
+++ b/src/symmetric/prf.rs
@@ -1,5 +1,5 @@
 use rand::Rng;
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 
 /// Trait to model a pseudorandom function
 pub trait Pseudorandom {
@@ -7,7 +7,7 @@ pub trait Pseudorandom {
     type Output;
 
     /// Sample a random domain element
-    fn gen<R: Rng>(rng: &mut R) -> Self::Key;
+    fn random<R: Rng>(rng: &mut R) -> Self::Key;
 
     /// Apply the one-way function to an epoch and an index
     fn apply(key: &Self::Key, epoch: u32, index: u64) -> Self::Output;

--- a/src/symmetric/prf/sha.rs
+++ b/src/symmetric/prf/sha.rs
@@ -1,5 +1,5 @@
 use super::Pseudorandom;
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 use sha3::{Digest, Sha3_256};
 
 const KEY_LENGTH: usize = 32; // 32 bytes
@@ -18,7 +18,7 @@ where
     type Key = [u8; KEY_LENGTH];
     type Output = [u8; OUTPUT_LENGTH];
 
-    fn gen<R: rand::Rng>(rng: &mut R) -> Self::Key {
+    fn random<R: rand::Rng>(rng: &mut R) -> Self::Key {
         rng.random()
     }
 
@@ -65,7 +65,7 @@ mod tests {
         let mut all_same_count = 0;
 
         for _ in 0..K {
-            let key = PRF::gen(&mut rng);
+            let key = PRF::random(&mut rng);
 
             let first = key[0];
             if key.iter().all(|&x| x == first) {

--- a/src/symmetric/prf/shake_to_field.rs
+++ b/src/symmetric/prf/shake_to_field.rs
@@ -2,10 +2,10 @@ use super::Pseudorandom;
 use p3_baby_bear::BabyBear;
 use p3_field::PrimeCharacteristicRing;
 use p3_field::PrimeField64;
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 use sha3::{
-    digest::{ExtendableOutput, Update, XofReader},
     Shake128,
+    digest::{ExtendableOutput, Update, XofReader},
 };
 
 use num_bigint::BigUint;
@@ -32,7 +32,7 @@ where
     type Key = [u8; KEY_LENGTH];
     type Output = [F; OUTPUT_LENGTH_FE];
 
-    fn gen<R: rand::Rng>(rng: &mut R) -> Self::Key {
+    fn random<R: rand::Rng>(rng: &mut R) -> Self::Key {
         rng.random()
     }
 
@@ -91,7 +91,7 @@ mod tests {
         let mut all_same_count = 0;
 
         for _ in 0..K {
-            let key = PRF::gen(&mut rng);
+            let key = PRF::random(&mut rng);
 
             let first = key[0];
             if key.iter().all(|&x| x == first) {

--- a/src/symmetric/tweak_hash.rs
+++ b/src/symmetric/tweak_hash.rs
@@ -1,5 +1,5 @@
 use rand::Rng;
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 
 /// Trait to model a tweakable hash function.
 /// Such a function takes a public parameter, a tweak, and a

--- a/src/symmetric/tweak_hash/poseidon.rs
+++ b/src/symmetric/tweak_hash/poseidon.rs
@@ -1,10 +1,10 @@
+use p3_baby_bear::BabyBear;
 use p3_baby_bear::default_babybear_poseidon2_16;
 use p3_baby_bear::default_babybear_poseidon2_24;
-use p3_baby_bear::BabyBear;
 use p3_field::PrimeCharacteristicRing;
 use p3_field::PrimeField64;
 use p3_symmetric::Permutation;
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 
 use crate::TWEAK_SEPARATOR_FOR_CHAIN_HASH;
 use crate::TWEAK_SEPARATOR_FOR_TREE_HASH;
@@ -239,12 +239,12 @@ pub struct PoseidonTweakHash<
 >;
 
 impl<
-        const PARAMETER_LEN: usize,
-        const HASH_LEN: usize,
-        const TWEAK_LEN: usize,
-        const CAPACITY: usize,
-        const NUM_CHUNKS: usize,
-    > TweakableHash for PoseidonTweakHash<PARAMETER_LEN, HASH_LEN, TWEAK_LEN, CAPACITY, NUM_CHUNKS>
+    const PARAMETER_LEN: usize,
+    const HASH_LEN: usize,
+    const TWEAK_LEN: usize,
+    const CAPACITY: usize,
+    const NUM_CHUNKS: usize,
+> TweakableHash for PoseidonTweakHash<PARAMETER_LEN, HASH_LEN, TWEAK_LEN, CAPACITY, NUM_CHUNKS>
 where
     [F; PARAMETER_LEN]: Serialize + DeserializeOwned,
     [F; HASH_LEN]: Serialize + DeserializeOwned,

--- a/src/symmetric/tweak_hash/sha.rs
+++ b/src/symmetric/tweak_hash/sha.rs
@@ -1,4 +1,4 @@
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 use sha3::{Digest, Sha3_256};
 
 use crate::{TWEAK_SEPARATOR_FOR_CHAIN_HASH, TWEAK_SEPARATOR_FOR_TREE_HASH};


### PR DESCRIPTION
- Fmt changes due to edition = "2021" -> edition = "2024"
- `gen` is now a reserved word so we cannot use it (I used the same migration name as `rand` crate did: `gen` -> `random`).