### PR TITLE
cargo fmt: new rules

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,8 +16,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check
         run: cargo check
-      - name: Format Check
-        run: cargo fmt -- --check
       - name: Build
         run: cargo build --verbose
       - name: Run tests
@@ -37,3 +35,17 @@ jobs:
 
       - name: Clippy Check
         run: cargo clippy --workspace --lib --examples --tests --benches --all-features -- -D warnings
+
+  cargo-fmt:
+    name: Cargo fmt
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install nightly toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: nightly
+          components: rustfmt
+      - name: Rustfmt Check
+        run: cargo fmt --all --check

--- a/benches/benchmark_poseidon.rs
+++ b/benches/benchmark_poseidon.rs
@@ -1,6 +1,4 @@
 use criterion::{Criterion, SamplingMode, black_box};
-use rand::Rng;
-
 use hashsig::{
     MESSAGE_LENGTH,
     signature::{
@@ -33,6 +31,7 @@ use hashsig::{
         },
     },
 };
+use rand::Rng;
 
 /// A template for benchmarking signature schemes (key gen, signing, verification)
 pub fn benchmark_signature_scheme<S: SignatureScheme>(c: &mut Criterion, description: &str) {

--- a/benches/benchmark_poseidon_top_level.rs
+++ b/benches/benchmark_poseidon_top_level.rs
@@ -1,8 +1,6 @@
 use std::cmp::min;
 
 use criterion::{Criterion, SamplingMode, black_box};
-use rand::Rng;
-
 use hashsig::{
     MESSAGE_LENGTH,
     signature::{
@@ -17,6 +15,7 @@ use hashsig::{
         },
     },
 };
+use rand::Rng;
 
 /// We will benchmark with actual lifetime min(LIFETIME, 1 << MAX_LOG_ACTIVATION_DURATION)
 /// to keep key generation time within reasonable limits.

--- a/benches/benchmark_sha.rs
+++ b/benches/benchmark_sha.rs
@@ -1,6 +1,4 @@
 use criterion::{Criterion, SamplingMode, black_box};
-use rand::Rng;
-
 use hashsig::{
     MESSAGE_LENGTH,
     signature::{
@@ -33,6 +31,7 @@ use hashsig::{
         },
     },
 };
+use rand::Rng;
 
 /// A template for benchmarking signature schemes (key gen, signing, verification)
 pub fn benchmark_signature_scheme<S: SignatureScheme>(c: &mut Criterion, description: &str) {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+reorder_imports = true
+imports_granularity = "Crate"
+group_imports = "StdExternalCrate"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,23 +1,31 @@
-use hashsig::signature::generalized_xmss::instantiations_poseidon::lifetime_2_to_the_18::target_sum::SIGTargetSumLifetime18W1NoOff;
-use hashsig::signature::generalized_xmss::instantiations_poseidon::lifetime_2_to_the_18::target_sum::SIGTargetSumLifetime18W2NoOff;
-use hashsig::signature::generalized_xmss::instantiations_poseidon::lifetime_2_to_the_18::target_sum::SIGTargetSumLifetime18W4NoOff;
-use hashsig::signature::generalized_xmss::instantiations_poseidon::lifetime_2_to_the_18::target_sum::SIGTargetSumLifetime18W8NoOff;
-use hashsig::signature::generalized_xmss::instantiations_poseidon::lifetime_2_to_the_18::winternitz::SIGWinternitzLifetime18W1;
-use hashsig::signature::generalized_xmss::instantiations_poseidon::lifetime_2_to_the_18::winternitz::SIGWinternitzLifetime18W2;
-use hashsig::signature::generalized_xmss::instantiations_poseidon::lifetime_2_to_the_18::winternitz::SIGWinternitzLifetime18W4;
-use hashsig::signature::generalized_xmss::instantiations_poseidon::lifetime_2_to_the_18::winternitz::SIGWinternitzLifetime18W8;
-use hashsig::signature::generalized_xmss::instantiations_poseidon::lifetime_2_to_the_20::target_sum::SIGTargetSumLifetime20W1NoOff;
-use hashsig::signature::generalized_xmss::instantiations_poseidon::lifetime_2_to_the_20::target_sum::SIGTargetSumLifetime20W2NoOff;
-use hashsig::signature::generalized_xmss::instantiations_poseidon::lifetime_2_to_the_20::target_sum::SIGTargetSumLifetime20W4NoOff;
-use hashsig::signature::generalized_xmss::instantiations_poseidon::lifetime_2_to_the_20::target_sum::SIGTargetSumLifetime20W8NoOff;
-use hashsig::signature::generalized_xmss::instantiations_poseidon::lifetime_2_to_the_20::winternitz::SIGWinternitzLifetime20W1;
-use hashsig::signature::generalized_xmss::instantiations_poseidon::lifetime_2_to_the_20::winternitz::SIGWinternitzLifetime20W2;
-use hashsig::signature::generalized_xmss::instantiations_poseidon::lifetime_2_to_the_20::winternitz::SIGWinternitzLifetime20W4;
-use hashsig::signature::generalized_xmss::instantiations_poseidon::lifetime_2_to_the_20::winternitz::SIGWinternitzLifetime20W8;
-use hashsig::signature::SignatureScheme;
-use rand::rngs::ThreadRng;
-use rand::Rng;
 use std::time::Instant;
+
+use hashsig::signature::{
+    SignatureScheme,
+    generalized_xmss::instantiations_poseidon::{
+        lifetime_2_to_the_18::{
+            target_sum::{
+                SIGTargetSumLifetime18W1NoOff, SIGTargetSumLifetime18W2NoOff,
+                SIGTargetSumLifetime18W4NoOff, SIGTargetSumLifetime18W8NoOff,
+            },
+            winternitz::{
+                SIGWinternitzLifetime18W1, SIGWinternitzLifetime18W2, SIGWinternitzLifetime18W4,
+                SIGWinternitzLifetime18W8,
+            },
+        },
+        lifetime_2_to_the_20::{
+            target_sum::{
+                SIGTargetSumLifetime20W1NoOff, SIGTargetSumLifetime20W2NoOff,
+                SIGTargetSumLifetime20W4NoOff, SIGTargetSumLifetime20W8NoOff,
+            },
+            winternitz::{
+                SIGWinternitzLifetime20W1, SIGWinternitzLifetime20W2, SIGWinternitzLifetime20W4,
+                SIGWinternitzLifetime20W8,
+            },
+        },
+    },
+};
+use rand::{Rng, rngs::ThreadRng};
 
 // Function to measure execution time
 fn measure_time<T: SignatureScheme, R: Rng>(description: &str, rng: &mut R) {

--- a/src/hypercube.rs
+++ b/src/hypercube.rs
@@ -1,12 +1,8 @@
-use dashmap::DashMap;
-use dashmap::mapref::one::Ref;
+use std::{cmp::min, ops::RangeInclusive, sync::LazyLock};
+
+use dashmap::{DashMap, mapref::one::Ref};
 use num_bigint::BigUint;
-use num_traits::One;
-use num_traits::ToPrimitive;
-use num_traits::Zero;
-use std::cmp::min;
-use std::ops::RangeInclusive;
-use std::sync::LazyLock;
+use num_traits::{One, ToPrimitive, Zero};
 
 /// Max dimension precomputed for layer sizes.
 const MAX_DIMENSION: usize = 100;
@@ -260,13 +256,13 @@ pub fn map_to_integer(w: usize, v: usize, d: usize, a: &[u8]) -> BigUint {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use num_bigint::{BigInt, BigUint};
-    use num_traits::FromPrimitive;
-    use num_traits::ToPrimitive;
-    use num_traits::Zero;
-    use proptest::prelude::*;
     use std::sync::Mutex;
+
+    use num_bigint::{BigInt, BigUint};
+    use num_traits::{FromPrimitive, ToPrimitive, Zero};
+    use proptest::prelude::*;
+
+    use super::*;
 
     // Reference implementation for testing purposes
     fn prepare_layer_sizes_by_binom(w: usize) -> Vec<Vec<BigUint>> {

--- a/src/inc_encoding/basic_winternitz.rs
+++ b/src/inc_encoding/basic_winternitz.rs
@@ -1,9 +1,8 @@
+use super::IncomparableEncoding;
 use crate::{
     MESSAGE_LENGTH,
     symmetric::message_hash::{MessageHash, bytes_to_chunks},
 };
-
-use super::IncomparableEncoding;
 
 /// Incomparable Encoding Scheme based on the basic
 /// Winternitz scheme, implemented from a given message hash.

--- a/src/inc_encoding/target_sum.rs
+++ b/src/inc_encoding/target_sum.rs
@@ -1,6 +1,5 @@
-use crate::{MESSAGE_LENGTH, symmetric::message_hash::MessageHash};
-
 use super::IncomparableEncoding;
+use crate::{MESSAGE_LENGTH, symmetric::message_hash::MessageHash};
 
 /// Incomparable Encoding Scheme based on Target Sums,
 /// implemented from a given message hash.

--- a/src/signature/generalized_xmss.rs
+++ b/src/signature/generalized_xmss.rs
@@ -2,6 +2,7 @@ use rand::Rng;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
+use super::{SignatureScheme, SigningError};
 use crate::{
     MESSAGE_LENGTH,
     inc_encoding::IncomparableEncoding,
@@ -11,8 +12,6 @@ use crate::{
         tweak_hash_tree::{HashTree, HashTreeOpening, hash_tree_verify},
     },
 };
-
-use super::{SignatureScheme, SigningError};
 
 /// Implementation of the generalized XMSS signature scheme
 /// from any incomparable encoding scheme and any tweakable hash
@@ -329,6 +328,7 @@ pub mod instantiations_sha;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::{
         inc_encoding::{basic_winternitz::WinternitzEncoding, target_sum::TargetSumEncoding},
         signature::test_templates::test_signature_scheme_correctness,
@@ -342,8 +342,6 @@ mod tests {
             tweak_hash::{poseidon::PoseidonTweakW1L5, sha::ShaTweak192192},
         },
     };
-
-    use super::*;
 
     #[test]
     pub fn test_winternitz() {

--- a/src/signature/generalized_xmss/instantiations_poseidon.rs
+++ b/src/signature/generalized_xmss/instantiations_poseidon.rs
@@ -110,15 +110,13 @@ pub mod lifetime_2_to_the_18 {
 
         #[cfg(test)]
         mod test {
-            use crate::signature::SignatureScheme;
-
-            #[cfg(feature = "slow-tests")]
-            use crate::signature::test_templates::test_signature_scheme_correctness;
-
             use super::{
                 SIGWinternitzLifetime18W1, SIGWinternitzLifetime18W2, SIGWinternitzLifetime18W4,
                 SIGWinternitzLifetime18W8,
             };
+            use crate::signature::SignatureScheme;
+            #[cfg(feature = "slow-tests")]
+            use crate::signature::test_templates::test_signature_scheme_correctness;
 
             #[test]
             pub fn test_w1_internal_consistency() {
@@ -307,17 +305,15 @@ pub mod lifetime_2_to_the_18 {
 
         #[cfg(test)]
         mod test {
-            use crate::signature::SignatureScheme;
-
-            #[cfg(feature = "slow-tests")]
-            use crate::signature::test_templates::test_signature_scheme_correctness;
-
             use super::{
                 SIGTargetSumLifetime18W1NoOff, SIGTargetSumLifetime18W1Off10,
                 SIGTargetSumLifetime18W2NoOff, SIGTargetSumLifetime18W2Off10,
                 SIGTargetSumLifetime18W4NoOff, SIGTargetSumLifetime18W4Off10,
                 SIGTargetSumLifetime18W8NoOff, SIGTargetSumLifetime18W8Off10,
             };
+            use crate::signature::SignatureScheme;
+            #[cfg(feature = "slow-tests")]
+            use crate::signature::test_templates::test_signature_scheme_correctness;
 
             #[test]
             pub fn test_w1_internal_consistency() {
@@ -513,15 +509,13 @@ pub mod lifetime_2_to_the_20 {
 
         #[cfg(test)]
         mod test {
-            use crate::signature::SignatureScheme;
-
-            #[cfg(feature = "slow-tests")]
-            use crate::signature::test_templates::test_signature_scheme_correctness;
-
             use super::{
                 SIGWinternitzLifetime20W1, SIGWinternitzLifetime20W2, SIGWinternitzLifetime20W4,
                 SIGWinternitzLifetime20W8,
             };
+            use crate::signature::SignatureScheme;
+            #[cfg(feature = "slow-tests")]
+            use crate::signature::test_templates::test_signature_scheme_correctness;
 
             #[test]
             pub fn test_w1_internal_consistency() {
@@ -711,17 +705,15 @@ pub mod lifetime_2_to_the_20 {
 
         #[cfg(test)]
         mod test {
-            use crate::signature::SignatureScheme;
-
-            #[cfg(feature = "slow-tests")]
-            use crate::signature::test_templates::test_signature_scheme_correctness;
-
             use super::{
                 SIGTargetSumLifetime20W1NoOff, SIGTargetSumLifetime20W1Off10,
                 SIGTargetSumLifetime20W2NoOff, SIGTargetSumLifetime20W2Off10,
                 SIGTargetSumLifetime20W4NoOff, SIGTargetSumLifetime20W4Off10,
                 SIGTargetSumLifetime20W8NoOff, SIGTargetSumLifetime20W8Off10,
             };
+            use crate::signature::SignatureScheme;
+            #[cfg(feature = "slow-tests")]
+            use crate::signature::test_templates::test_signature_scheme_correctness;
 
             #[test]
             pub fn test_w1_internal_consistency() {

--- a/src/signature/generalized_xmss/instantiations_poseidon_top_level.rs
+++ b/src/signature/generalized_xmss/instantiations_poseidon_top_level.rs
@@ -48,14 +48,12 @@ pub mod lifetime_2_to_the_18 {
 
     #[cfg(test)]
     mod test {
-
+        #[cfg(feature = "slow-tests")]
+        use crate::signature::test_templates::test_signature_scheme_correctness;
         use crate::signature::{
             SignatureScheme,
             generalized_xmss::instantiations_poseidon_top_level::lifetime_2_to_the_18::SIGTopLevelTargetSumLifetime18Dim64Base8,
         };
-
-        #[cfg(feature = "slow-tests")]
-        use crate::signature::test_templates::test_signature_scheme_correctness;
 
         #[test]
         pub fn test_internal_consistency() {
@@ -136,7 +134,6 @@ pub mod lifetime_2_to_the_32 {
 
             use super::*;
             use crate::signature::SignatureScheme;
-
             #[cfg(feature = "slow-tests")]
             use crate::signature::test_templates::test_signature_scheme_correctness;
 
@@ -217,7 +214,6 @@ pub mod lifetime_2_to_the_32 {
 
             use super::*;
             use crate::signature::SignatureScheme;
-
             #[cfg(feature = "slow-tests")]
             use crate::signature::test_templates::test_signature_scheme_correctness;
 
@@ -297,7 +293,6 @@ pub mod lifetime_2_to_the_32 {
 
             use super::*;
             use crate::signature::SignatureScheme;
-
             #[cfg(feature = "slow-tests")]
             use crate::signature::test_templates::test_signature_scheme_correctness;
 

--- a/src/signature/generalized_xmss/instantiations_sha.rs
+++ b/src/signature/generalized_xmss/instantiations_sha.rs
@@ -61,15 +61,13 @@ pub mod lifetime_2_to_the_18 {
 
         #[cfg(test)]
         mod test {
-            use crate::signature::SignatureScheme;
-
-            #[cfg(feature = "slow-tests")]
-            use crate::signature::test_templates::test_signature_scheme_correctness;
-
             use super::{
                 SIGWinternitzLifetime18W1, SIGWinternitzLifetime18W2, SIGWinternitzLifetime18W4,
                 SIGWinternitzLifetime18W8,
             };
+            use crate::signature::SignatureScheme;
+            #[cfg(feature = "slow-tests")]
+            use crate::signature::test_templates::test_signature_scheme_correctness;
 
             #[test]
             pub fn test_w1_internal_consistency() {
@@ -213,17 +211,15 @@ pub mod lifetime_2_to_the_18 {
 
         #[cfg(test)]
         mod test {
-            use crate::signature::SignatureScheme;
-
-            #[cfg(feature = "slow-tests")]
-            use crate::signature::test_templates::test_signature_scheme_correctness;
-
             use super::{
                 SIGTargetSumLifetime18W1NoOff, SIGTargetSumLifetime18W1Off10,
                 SIGTargetSumLifetime18W2NoOff, SIGTargetSumLifetime18W2Off10,
                 SIGTargetSumLifetime18W4NoOff, SIGTargetSumLifetime18W4Off10,
                 SIGTargetSumLifetime18W8NoOff, SIGTargetSumLifetime18W8Off10,
             };
+            use crate::signature::SignatureScheme;
+            #[cfg(feature = "slow-tests")]
+            use crate::signature::test_templates::test_signature_scheme_correctness;
 
             #[test]
             pub fn test_w1_internal_consistency() {
@@ -370,15 +366,13 @@ pub mod lifetime_2_to_the_20 {
 
         #[cfg(test)]
         mod test {
-            #[cfg(feature = "slow-tests")]
-            use crate::signature::test_templates::test_signature_scheme_correctness;
-
-            use crate::signature::SignatureScheme;
-
             use super::{
                 SIGWinternitzLifetime20W1, SIGWinternitzLifetime20W2, SIGWinternitzLifetime20W4,
                 SIGWinternitzLifetime20W8,
             };
+            use crate::signature::SignatureScheme;
+            #[cfg(feature = "slow-tests")]
+            use crate::signature::test_templates::test_signature_scheme_correctness;
 
             #[test]
             pub fn test_w1_internal_consistency() {
@@ -523,17 +517,15 @@ pub mod lifetime_2_to_the_20 {
 
         #[cfg(test)]
         mod test {
-            #[cfg(feature = "slow-tests")]
-            use crate::signature::test_templates::test_signature_scheme_correctness;
-
-            use crate::signature::SignatureScheme;
-
             use super::{
                 SIGTargetSumLifetime20W1NoOff, SIGTargetSumLifetime20W1Off10,
                 SIGTargetSumLifetime20W2NoOff, SIGTargetSumLifetime20W2Off10,
                 SIGTargetSumLifetime20W4NoOff, SIGTargetSumLifetime20W4Off10,
                 SIGTargetSumLifetime20W8NoOff, SIGTargetSumLifetime20W8Off10,
             };
+            use crate::signature::SignatureScheme;
+            #[cfg(feature = "slow-tests")]
+            use crate::signature::test_templates::test_signature_scheme_correctness;
 
             #[test]
             pub fn test_w1_internal_consistency() {

--- a/src/symmetric/message_hash/poseidon.rs
+++ b/src/symmetric/message_hash/poseidon.rs
@@ -1,15 +1,13 @@
 use num_bigint::BigUint;
-use p3_baby_bear::BabyBear;
-use p3_baby_bear::default_babybear_poseidon2_24;
-use p3_field::PrimeCharacteristicRing;
-use p3_field::PrimeField;
-use p3_field::PrimeField64;
+use p3_baby_bear::{BabyBear, default_babybear_poseidon2_24};
+use p3_field::{PrimeCharacteristicRing, PrimeField, PrimeField64};
 use serde::{Serialize, de::DeserializeOwned};
 
 use super::MessageHash;
-use crate::MESSAGE_LENGTH;
-use crate::TWEAK_SEPARATOR_FOR_MESSAGE_HASH;
-use crate::symmetric::tweak_hash::poseidon::poseidon_compress;
+use crate::{
+    MESSAGE_LENGTH, TWEAK_SEPARATOR_FOR_MESSAGE_HASH,
+    symmetric::tweak_hash::poseidon::poseidon_compress,
+};
 
 type F = BabyBear;
 
@@ -200,10 +198,12 @@ pub type PoseidonMessageHashW1 = PoseidonMessageHash<5, 5, 5, 163, 2, 2, 9>;
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::collections::HashMap;
+
     use num_traits::Zero;
     use rand::Rng;
-    use std::collections::HashMap;
+
+    use super::*;
 
     #[test]
     fn test_apply() {

--- a/src/symmetric/message_hash/sha.rs
+++ b/src/symmetric/message_hash/sha.rs
@@ -1,11 +1,10 @@
+use serde::{Serialize, de::DeserializeOwned};
+use sha3::{Digest, Sha3_256};
+
+use super::MessageHash;
 use crate::{
     MESSAGE_LENGTH, TWEAK_SEPARATOR_FOR_MESSAGE_HASH, symmetric::message_hash::bytes_to_chunks,
 };
-use serde::{Serialize, de::DeserializeOwned};
-
-use super::MessageHash;
-
-use sha3::{Digest, Sha3_256};
 
 /// A message hash implemented using SHA3
 /// All lengths must be given in Bytes.

--- a/src/symmetric/message_hash/top_level_poseidon.rs
+++ b/src/symmetric/message_hash/top_level_poseidon.rs
@@ -1,19 +1,17 @@
 use num_bigint::BigUint;
-use p3_baby_bear::BabyBear;
-use p3_baby_bear::default_babybear_poseidon2_24;
-use p3_field::PrimeCharacteristicRing;
-use p3_field::PrimeField;
-use p3_field::PrimeField64;
+use p3_baby_bear::{BabyBear, default_babybear_poseidon2_24};
+use p3_field::{PrimeCharacteristicRing, PrimeField, PrimeField64};
 use serde::{Serialize, de::DeserializeOwned};
 
-use super::MessageHash;
-use super::poseidon::encode_epoch;
-use super::poseidon::encode_message;
-use crate::MESSAGE_LENGTH;
-use crate::hypercube::hypercube_find_layer;
-use crate::hypercube::hypercube_part_size;
-use crate::hypercube::map_to_vertex;
-use crate::symmetric::tweak_hash::poseidon::poseidon_compress;
+use super::{
+    MessageHash,
+    poseidon::{encode_epoch, encode_message},
+};
+use crate::{
+    MESSAGE_LENGTH,
+    hypercube::{hypercube_find_layer, hypercube_part_size, map_to_vertex},
+    symmetric::tweak_hash::poseidon::poseidon_compress,
+};
 
 type F = BabyBear;
 
@@ -240,10 +238,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use proptest::prelude::*;
     use rand::Rng;
 
+    use super::*;
     use crate::symmetric::message_hash::{
         MessageHash, top_level_poseidon::TopLevelPoseidonMessageHash,
     };

--- a/src/symmetric/prf/sha.rs
+++ b/src/symmetric/prf/sha.rs
@@ -1,6 +1,7 @@
-use super::Pseudorandom;
 use serde::{Serialize, de::DeserializeOwned};
 use sha3::{Digest, Sha3_256};
+
+use super::Pseudorandom;
 
 const KEY_LENGTH: usize = 32; // 32 bytes
 const PRF_DOMAIN_SEP: [u8; 16] = [

--- a/src/symmetric/prf/shake_to_field.rs
+++ b/src/symmetric/prf/shake_to_field.rs
@@ -1,14 +1,13 @@
-use super::Pseudorandom;
+use num_bigint::BigUint;
 use p3_baby_bear::BabyBear;
-use p3_field::PrimeCharacteristicRing;
-use p3_field::PrimeField64;
+use p3_field::{PrimeCharacteristicRing, PrimeField64};
 use serde::{Serialize, de::DeserializeOwned};
 use sha3::{
     Shake128,
     digest::{ExtendableOutput, Update, XofReader},
 };
 
-use num_bigint::BigUint;
+use super::Pseudorandom;
 
 type F = BabyBear;
 

--- a/src/symmetric/tweak_hash.rs
+++ b/src/symmetric/tweak_hash.rs
@@ -78,10 +78,10 @@ pub mod sha;
 
 #[cfg(test)]
 mod tests {
+    use proptest::prelude::*;
     use sha::ShaTweak128192;
 
     use super::*;
-    use proptest::prelude::*;
 
     type TestTH = ShaTweak128192;
 

--- a/src/symmetric/tweak_hash/poseidon.rs
+++ b/src/symmetric/tweak_hash/poseidon.rs
@@ -1,15 +1,10 @@
-use p3_baby_bear::BabyBear;
-use p3_baby_bear::default_babybear_poseidon2_16;
-use p3_baby_bear::default_babybear_poseidon2_24;
-use p3_field::PrimeCharacteristicRing;
-use p3_field::PrimeField64;
+use p3_baby_bear::{BabyBear, default_babybear_poseidon2_16, default_babybear_poseidon2_24};
+use p3_field::{PrimeCharacteristicRing, PrimeField64};
 use p3_symmetric::Permutation;
 use serde::{Serialize, de::DeserializeOwned};
 
-use crate::TWEAK_SEPARATOR_FOR_CHAIN_HASH;
-use crate::TWEAK_SEPARATOR_FOR_TREE_HASH;
-
 use super::TweakableHash;
+use crate::{TWEAK_SEPARATOR_FOR_CHAIN_HASH, TWEAK_SEPARATOR_FOR_TREE_HASH};
 
 type F = BabyBear;
 

--- a/src/symmetric/tweak_hash/sha.rs
+++ b/src/symmetric/tweak_hash/sha.rs
@@ -1,9 +1,8 @@
 use serde::{Serialize, de::DeserializeOwned};
 use sha3::{Digest, Sha3_256};
 
-use crate::{TWEAK_SEPARATOR_FOR_CHAIN_HASH, TWEAK_SEPARATOR_FOR_TREE_HASH};
-
 use super::TweakableHash;
+use crate::{TWEAK_SEPARATOR_FOR_CHAIN_HASH, TWEAK_SEPARATOR_FOR_TREE_HASH};
 
 /// Enum to implement tweaks.
 pub enum ShaTweak {

--- a/src/symmetric/tweak_hash_tree.rs
+++ b/src/symmetric/tweak_hash_tree.rs
@@ -1,7 +1,8 @@
-use crate::symmetric::tweak_hash::TweakableHash;
 use rand::Rng;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
+
+use crate::symmetric::tweak_hash::TweakableHash;
 
 /// A single layer of a sparse Hash-Tree
 /// based on tweakable hash function
@@ -256,9 +257,8 @@ mod tests {
 
     use proptest::prelude::*;
 
-    use crate::symmetric::tweak_hash::sha::ShaTweak128192;
-
     use super::*;
+    use crate::symmetric::tweak_hash::sha::ShaTweak128192;
 
     type TestTH = ShaTweak128192;
 


### PR DESCRIPTION
This is a suggestion (please feel free to close if you feel this is inappropriate).

In other repos like https://github.com/paradigmxyz/reth or https://github.com/tcoratger/whir-p3, we've found that these rules for classifying imports via cargo fmt:
```
reorder_imports = true
imports_granularity = "Crate"
group_imports = "StdExternalCrate"
```

makes life easier for the user by automatically classifying imports without the user having to do anything and also minimizes the risk of Git conflicts due to this automatic classification.

The only drawback is that `imports_granularity = "Crate"` and `group_imports = "StdExternalCrate"` are not available on `cargo fmt` stable, but only on nightly releases. This is not a problem when you do a save in your file in the code editor (the rule applies automatically). But if you want to do a `cargo fmt` in the whole repo then these two rules will not apply and it is possible for the CI to fail because of this, so you will have to do `cargo +nightly fmt` instead to solve this.