### PR TITLE
encoding: make `EncodingError` a proper enum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ rayon = "1.10.0"
 num-traits = "0.2.19"
 dashmap = "6.1.0"
 serde = { version = "1.0", features = ["derive", "alloc"] }
+thiserror = "2.0"
 
 p3-field = { git = "https://github.com/Plonky3/Plonky3.git", rev = "d0c4a36" }
 p3-baby-bear = { git = "https://github.com/Plonky3/Plonky3.git", rev = "d0c4a36" }

--- a/src/inc_encoding.rs
+++ b/src/inc_encoding.rs
@@ -1,17 +1,8 @@
 use rand::Rng;
 use serde::{Serialize, de::DeserializeOwned};
-use target_sum::TargetSumError;
-use thiserror::Error;
+use std::fmt::Debug;
 
 use crate::MESSAGE_LENGTH;
-
-/// Error during the encoding process.
-#[derive(Debug, Error)]
-pub enum EncodingError {
-    /// An error originating from the target sum encoding scheme.
-    #[error(transparent)]
-    TargetSum(#[from] TargetSumError),
-}
 
 /// Trait to model incomparable encoding schemes.
 /// These schemes allow to encode a message into a codeword.
@@ -28,6 +19,7 @@ pub enum EncodingError {
 pub trait IncomparableEncoding {
     type Parameter: Serialize + DeserializeOwned;
     type Randomness: Serialize + DeserializeOwned;
+    type Error: Debug;
 
     /// number of entries in a codeword
     const DIMENSION: usize;
@@ -52,7 +44,7 @@ pub trait IncomparableEncoding {
         message: &[u8; MESSAGE_LENGTH],
         randomness: &Self::Randomness,
         epoch: u32,
-    ) -> Result<Vec<u8>, EncodingError>;
+    ) -> Result<Vec<u8>, Self::Error>;
 
     /// Function to check internal consistency of any given parameters
     /// For testing only, and expected to panic if something is wrong.

--- a/src/inc_encoding.rs
+++ b/src/inc_encoding.rs
@@ -1,5 +1,6 @@
 use rand::Rng;
 use serde::{Serialize, de::DeserializeOwned};
+use target_sum::TargetSumError;
 use thiserror::Error;
 
 use crate::MESSAGE_LENGTH;
@@ -7,8 +8,9 @@ use crate::MESSAGE_LENGTH;
 /// Error during the encoding process.
 #[derive(Debug, Error)]
 pub enum EncodingError {
-    #[error("Target sum mismatch: expected {expected}, but got {actual}.")]
-    TargetSumMismatch { expected: usize, actual: usize },
+    /// An error originating from the target sum encoding scheme.
+    #[error(transparent)]
+    TargetSum(#[from] TargetSumError),
 }
 
 /// Trait to model incomparable encoding schemes.

--- a/src/inc_encoding.rs
+++ b/src/inc_encoding.rs
@@ -45,7 +45,6 @@ pub trait IncomparableEncoding {
     /// It could happen that this fails. Otherwise,
     /// implementations must guarantee that the
     /// result is indeed a valid codeword.
-    #[allow(clippy::result_unit_err)]
     fn encode(
         parameter: &Self::Parameter,
         message: &[u8; MESSAGE_LENGTH],

--- a/src/inc_encoding.rs
+++ b/src/inc_encoding.rs
@@ -1,10 +1,15 @@
 use rand::Rng;
 use serde::{Serialize, de::DeserializeOwned};
+use thiserror::Error;
 
 use crate::MESSAGE_LENGTH;
 
-/// Error during encoding
-pub type EncodingError = ();
+/// Error during the encoding process.
+#[derive(Debug, Error)]
+pub enum EncodingError {
+    #[error("Target sum mismatch: expected {expected}, but got {actual}.")]
+    TargetSumMismatch { expected: usize, actual: usize },
+}
 
 /// Trait to model incomparable encoding schemes.
 /// These schemes allow to encode a message into a codeword.

--- a/src/inc_encoding/basic_winternitz.rs
+++ b/src/inc_encoding/basic_winternitz.rs
@@ -35,6 +35,8 @@ impl<MH: MessageHash, const CHUNK_SIZE: usize, const NUM_CHUNKS_CHECKSUM: usize>
 
     type Randomness = MH::Randomness;
 
+    type Error = ();
+
     const DIMENSION: usize = MH::DIMENSION + NUM_CHUNKS_CHECKSUM;
 
     const MAX_TRIES: usize = 1;
@@ -50,7 +52,7 @@ impl<MH: MessageHash, const CHUNK_SIZE: usize, const NUM_CHUNKS_CHECKSUM: usize>
         message: &[u8; MESSAGE_LENGTH],
         randomness: &Self::Randomness,
         epoch: u32,
-    ) -> Result<Vec<u8>, super::EncodingError> {
+    ) -> Result<Vec<u8>, Self::Error> {
         // apply the message hash to get chunks
         let mut chunks_message = MH::apply(parameter, epoch, randomness, message);
 

--- a/src/inc_encoding/target_sum.rs
+++ b/src/inc_encoding/target_sum.rs
@@ -1,6 +1,6 @@
 use crate::{MESSAGE_LENGTH, symmetric::message_hash::MessageHash};
 
-use super::{EncodingError, IncomparableEncoding};
+use super::IncomparableEncoding;
 use thiserror::Error;
 
 /// Specific errors that can occur during target sum encoding.
@@ -35,6 +35,8 @@ impl<MH: MessageHash, const TARGET_SUM: usize> IncomparableEncoding
 
     type Randomness = MH::Randomness;
 
+    type Error = TargetSumError;
+
     const DIMENSION: usize = MH::DIMENSION;
 
     /// we did one experiment with random message hashes.
@@ -53,7 +55,7 @@ impl<MH: MessageHash, const TARGET_SUM: usize> IncomparableEncoding
         message: &[u8; MESSAGE_LENGTH],
         randomness: &Self::Randomness,
         epoch: u32,
-    ) -> Result<Vec<u8>, EncodingError> {
+    ) -> Result<Vec<u8>, Self::Error> {
         // apply the message hash first to get chunks
         let chunks = MH::apply(parameter, epoch, randomness, message);
         let sum: u32 = chunks.iter().map(|&x| x as u32).sum();
@@ -64,8 +66,7 @@ impl<MH: MessageHash, const TARGET_SUM: usize> IncomparableEncoding
             Err(TargetSumError::Mismatch {
                 expected: TARGET_SUM,
                 actual: sum as usize,
-            }
-            .into())
+            })
         }
     }
 

--- a/src/inc_encoding/target_sum.rs
+++ b/src/inc_encoding/target_sum.rs
@@ -1,6 +1,15 @@
 use crate::{MESSAGE_LENGTH, symmetric::message_hash::MessageHash};
 
 use super::{EncodingError, IncomparableEncoding};
+use thiserror::Error;
+
+/// Specific errors that can occur during target sum encoding.
+#[derive(Debug, Error)]
+pub enum TargetSumError {
+    /// Returned when the generated chunks do not sum to the required target.
+    #[error("Target sum mismatch: expected {expected}, but got {actual}.")]
+    Mismatch { expected: usize, actual: usize },
+}
 
 /// Incomparable Encoding Scheme based on Target Sums,
 /// implemented from a given message hash.
@@ -52,10 +61,11 @@ impl<MH: MessageHash, const TARGET_SUM: usize> IncomparableEncoding
         if sum as usize == TARGET_SUM {
             Ok(chunks)
         } else {
-            Err(EncodingError::TargetSumMismatch {
+            Err(TargetSumError::Mismatch {
                 expected: TARGET_SUM,
                 actual: sum as usize,
-            })
+            }
+            .into())
         }
     }
 

--- a/src/inc_encoding/target_sum.rs
+++ b/src/inc_encoding/target_sum.rs
@@ -1,6 +1,6 @@
 use crate::{MESSAGE_LENGTH, symmetric::message_hash::MessageHash};
 
-use super::IncomparableEncoding;
+use super::{EncodingError, IncomparableEncoding};
 
 /// Incomparable Encoding Scheme based on Target Sums,
 /// implemented from a given message hash.
@@ -44,7 +44,7 @@ impl<MH: MessageHash, const TARGET_SUM: usize> IncomparableEncoding
         message: &[u8; MESSAGE_LENGTH],
         randomness: &Self::Randomness,
         epoch: u32,
-    ) -> Result<Vec<u8>, super::EncodingError> {
+    ) -> Result<Vec<u8>, EncodingError> {
         // apply the message hash first to get chunks
         let chunks = MH::apply(parameter, epoch, randomness, message);
         let sum: u32 = chunks.iter().map(|&x| x as u32).sum();
@@ -52,7 +52,10 @@ impl<MH: MessageHash, const TARGET_SUM: usize> IncomparableEncoding
         if sum as usize == TARGET_SUM {
             Ok(chunks)
         } else {
-            Err(())
+            Err(EncodingError::TargetSumMismatch {
+                expected: TARGET_SUM,
+                actual: sum as usize,
+            })
         }
     }
 

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -6,7 +6,6 @@ use crate::MESSAGE_LENGTH;
 /// Error enum for signatures
 #[derive(Debug)]
 pub enum SigningError {
-    InvalidMessageLength,
     UnluckyFailure,
 }
 

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -1,12 +1,15 @@
+use crate::MESSAGE_LENGTH;
 use rand::Rng;
 use serde::{Serialize, de::DeserializeOwned};
+use thiserror::Error;
 
-use crate::MESSAGE_LENGTH;
-
-/// Error enum for signatures
-#[derive(Debug)]
+/// Error enum for the signing process.
+#[derive(Debug, Error)]
 pub enum SigningError {
-    UnluckyFailure,
+    /// Occurs when the probabilistic message encoding fails to produce a valid codeword
+    /// after the maximum number of attempts.
+    #[error("Failed to encode message after {attempts} attempts.")]
+    EncodingAttemptsExceeded { attempts: usize },
 }
 
 /// Trait to model a synchronized signature scheme.

--- a/src/signature/generalized_xmss.rs
+++ b/src/signature/generalized_xmss.rs
@@ -209,7 +209,9 @@ where
 
         // if we have not found a valid codeword, return an error
         if x.is_none() {
-            return Err(SigningError::UnluckyFailure);
+            return Err(SigningError::EncodingAttemptsExceeded {
+                attempts: max_tries,
+            });
         }
 
         // otherwise, unwrap x and rho


### PR DESCRIPTION
We use a proper error handling mechanism here for the encoding error in order to display it properly to the user with a meaningful message.