### PR TITLE
field: make field and perm generics

### DIFF
--- a/src/signature/generalized_xmss.rs
+++ b/src/signature/generalized_xmss.rs
@@ -329,6 +329,8 @@ pub mod instantiations_sha;
 
 #[cfg(test)]
 mod tests {
+    use p3_baby_bear::BabyBear;
+
     use crate::{
         inc_encoding::{basic_winternitz::WinternitzEncoding, target_sum::TargetSumEncoding},
         signature::test_templates::test_signature_scheme_correctness,
@@ -369,7 +371,7 @@ mod tests {
     #[test]
     pub fn test_winternitz_poseidon() {
         // Note: do not use these parameters, they are just for testing
-        type PRF = ShakePRFtoF<7>;
+        type PRF = ShakePRFtoF<BabyBear, 7>;
         type TH = PoseidonTweakW1L5;
         type MH = PoseidonMessageHashW1;
         const CHUNK_SIZE: usize = 1;
@@ -418,7 +420,7 @@ mod tests {
     #[test]
     pub fn test_target_sum_poseidon() {
         // Note: do not use these parameters, they are just for testing
-        type PRF = ShakePRFtoF<7>;
+        type PRF = ShakePRFtoF<BabyBear, 7>;
         type TH = PoseidonTweakW1L5;
         type MH = PoseidonMessageHashW1;
         const BASE: usize = MH::BASE;

--- a/src/signature/generalized_xmss/instantiations_poseidon.rs
+++ b/src/signature/generalized_xmss/instantiations_poseidon.rs
@@ -2,6 +2,8 @@
 pub mod lifetime_2_to_the_18 {
     /// Instantiations based on the Winternitz encoding
     pub mod winternitz {
+        use p3_baby_bear::BabyBear;
+
         use crate::{
             inc_encoding::basic_winternitz::WinternitzEncoding,
             signature::generalized_xmss::GeneralizedXMSSSignatureScheme,
@@ -36,7 +38,7 @@ pub mod lifetime_2_to_the_18 {
         >;
         type THw1 =
             PoseidonTweakHash<PARAMETER_LEN, HASH_LEN_FE, TWEAK_LEN_FE, CAPACITY, NUM_CHUNKS_W1>;
-        type PRFw1 = ShakePRFtoF<HASH_LEN_FE>;
+        type PRFw1 = ShakePRFtoF<BabyBear, HASH_LEN_FE>;
         type IEw1 = WinternitzEncoding<MHw1, CHUNK_SIZE_W1, NUM_CHUNKS_CHECKSUM_W1>;
         /// Instantiation with Lifetime 2^18, Winternitz encoding, chunk size w = 1
         pub type SIGWinternitzLifetime18W1 =
@@ -58,7 +60,7 @@ pub mod lifetime_2_to_the_18 {
         >;
         type THw2 =
             PoseidonTweakHash<PARAMETER_LEN, HASH_LEN_FE, TWEAK_LEN_FE, CAPACITY, NUM_CHUNKS_W2>;
-        type PRFw2 = ShakePRFtoF<HASH_LEN_FE>;
+        type PRFw2 = ShakePRFtoF<BabyBear, HASH_LEN_FE>;
         type IEw2 = WinternitzEncoding<MHw2, CHUNK_SIZE_W2, NUM_CHUNKS_CHECKSUM_W2>;
         /// Instantiation with Lifetime 2^18, Winternitz encoding, chunk size w = 2
         pub type SIGWinternitzLifetime18W2 =
@@ -80,7 +82,7 @@ pub mod lifetime_2_to_the_18 {
         >;
         type THw4 =
             PoseidonTweakHash<PARAMETER_LEN, HASH_LEN_FE, TWEAK_LEN_FE, CAPACITY, NUM_CHUNKS_W4>;
-        type PRFw4 = ShakePRFtoF<HASH_LEN_FE>;
+        type PRFw4 = ShakePRFtoF<BabyBear, HASH_LEN_FE>;
         type IEw4 = WinternitzEncoding<MHw4, CHUNK_SIZE_W4, NUM_CHUNKS_CHECKSUM_W4>;
         /// Instantiation with Lifetime 2^18, Winternitz encoding, chunk size w = 4
         pub type SIGWinternitzLifetime18W4 =
@@ -102,7 +104,7 @@ pub mod lifetime_2_to_the_18 {
         >;
         type THw8 =
             PoseidonTweakHash<PARAMETER_LEN, HASH_LEN_FE, TWEAK_LEN_FE, CAPACITY, NUM_CHUNKS_W8>;
-        type PRFw8 = ShakePRFtoF<HASH_LEN_FE>;
+        type PRFw8 = ShakePRFtoF<BabyBear, HASH_LEN_FE>;
         type IEw8 = WinternitzEncoding<MHw8, CHUNK_SIZE_W8, NUM_CHUNKS_CHECKSUM_W8>;
         /// Instantiation with Lifetime 2^18, Winternitz encoding, chunk size w = 8
         pub type SIGWinternitzLifetime18W8 =
@@ -177,6 +179,8 @@ pub mod lifetime_2_to_the_18 {
     }
     /// Instantiations based on the target sum encoding
     pub mod target_sum {
+        use p3_baby_bear::BabyBear;
+
         use crate::{
             inc_encoding::target_sum::TargetSumEncoding,
             signature::generalized_xmss::GeneralizedXMSSSignatureScheme,
@@ -210,7 +214,7 @@ pub mod lifetime_2_to_the_18 {
         >;
         type THw1 =
             PoseidonTweakHash<PARAMETER_LEN, HASH_LEN_FE, TWEAK_LEN_FE, CAPACITY, NUM_CHUNKS_W1>;
-        type PRFw1 = ShakePRFtoF<HASH_LEN_FE>;
+        type PRFw1 = ShakePRFtoF<BabyBear, HASH_LEN_FE>;
         type IEw1<const TARGET_SUM: usize> = TargetSumEncoding<MHw1, TARGET_SUM>;
         /// Instantiation with Lifetime 2^18, Target sum encoding, chunk size w = 1,
         /// and target sum set at expectation
@@ -236,7 +240,7 @@ pub mod lifetime_2_to_the_18 {
         >;
         type THw2 =
             PoseidonTweakHash<PARAMETER_LEN, HASH_LEN_FE, TWEAK_LEN_FE, CAPACITY, NUM_CHUNKS_W2>;
-        type PRFw2 = ShakePRFtoF<HASH_LEN_FE>;
+        type PRFw2 = ShakePRFtoF<BabyBear, HASH_LEN_FE>;
         type IEw2<const TARGET_SUM: usize> = TargetSumEncoding<MHw2, TARGET_SUM>;
         /// Instantiation with Lifetime 2^18, Target sum encoding, chunk size w = 2,
         /// and target sum set at expectation
@@ -262,7 +266,7 @@ pub mod lifetime_2_to_the_18 {
         >;
         type THw4 =
             PoseidonTweakHash<PARAMETER_LEN, HASH_LEN_FE, TWEAK_LEN_FE, CAPACITY, NUM_CHUNKS_W4>;
-        type PRFw4 = ShakePRFtoF<HASH_LEN_FE>;
+        type PRFw4 = ShakePRFtoF<BabyBear, HASH_LEN_FE>;
         type IEw4<const TARGET_SUM: usize> = TargetSumEncoding<MHw4, TARGET_SUM>;
         /// Instantiation with Lifetime 2^18, Target sum encoding, chunk size w = 4,
         /// and target sum set at expectation
@@ -288,7 +292,7 @@ pub mod lifetime_2_to_the_18 {
         >;
         type THw8 =
             PoseidonTweakHash<PARAMETER_LEN, HASH_LEN_FE, TWEAK_LEN_FE, CAPACITY, NUM_CHUNKS_W8>;
-        type PRFw8 = ShakePRFtoF<HASH_LEN_FE>;
+        type PRFw8 = ShakePRFtoF<BabyBear, HASH_LEN_FE>;
         type IEw8<const TARGET_SUM: usize> = TargetSumEncoding<MHw8, TARGET_SUM>;
         /// Instantiation with Lifetime 2^18, Target sum encoding, chunk size w = 8,
         /// and target sum set at expectation
@@ -404,6 +408,8 @@ pub mod lifetime_2_to_the_18 {
 pub mod lifetime_2_to_the_20 {
     /// Instantiations based on the Winternitz encoding
     pub mod winternitz {
+        use p3_baby_bear::BabyBear;
+
         use crate::{
             inc_encoding::basic_winternitz::WinternitzEncoding,
             signature::generalized_xmss::GeneralizedXMSSSignatureScheme,
@@ -438,7 +444,7 @@ pub mod lifetime_2_to_the_20 {
         >;
         type THw1 =
             PoseidonTweakHash<PARAMETER_LEN, HASH_LEN_FE, TWEAK_LEN_FE, CAPACITY, NUM_CHUNKS_W1>;
-        type PRFw1 = ShakePRFtoF<HASH_LEN_FE>;
+        type PRFw1 = ShakePRFtoF<BabyBear, HASH_LEN_FE>;
         type IEw1 = WinternitzEncoding<MHw1, CHUNK_SIZE_W1, NUM_CHUNKS_CHECKSUM_W1>;
         /// Instantiation with Lifetime 2^20, Winternitz encoding, chunk size w = 1
         pub type SIGWinternitzLifetime20W1 =
@@ -460,7 +466,7 @@ pub mod lifetime_2_to_the_20 {
         >;
         type THw2 =
             PoseidonTweakHash<PARAMETER_LEN, HASH_LEN_FE, TWEAK_LEN_FE, CAPACITY, NUM_CHUNKS_W2>;
-        type PRFw2 = ShakePRFtoF<HASH_LEN_FE>;
+        type PRFw2 = ShakePRFtoF<BabyBear, HASH_LEN_FE>;
         type IEw2 = WinternitzEncoding<MHw2, CHUNK_SIZE_W2, NUM_CHUNKS_CHECKSUM_W2>;
         /// Instantiation with Lifetime 2^20, Winternitz encoding, chunk size w = 2
         pub type SIGWinternitzLifetime20W2 =
@@ -482,7 +488,7 @@ pub mod lifetime_2_to_the_20 {
         >;
         type THw4 =
             PoseidonTweakHash<PARAMETER_LEN, HASH_LEN_FE, TWEAK_LEN_FE, CAPACITY, NUM_CHUNKS_W4>;
-        type PRFw4 = ShakePRFtoF<HASH_LEN_FE>;
+        type PRFw4 = ShakePRFtoF<BabyBear, HASH_LEN_FE>;
         type IEw4 = WinternitzEncoding<MHw4, CHUNK_SIZE_W4, NUM_CHUNKS_CHECKSUM_W4>;
         /// Instantiation with Lifetime 2^20, Winternitz encoding, chunk size w = 4
         pub type SIGWinternitzLifetime20W4 =
@@ -505,7 +511,7 @@ pub mod lifetime_2_to_the_20 {
         >;
         type THw8 =
             PoseidonTweakHash<PARAMETER_LEN, HASH_LEN_FE_W8, TWEAK_LEN_FE, CAPACITY, NUM_CHUNKS_W8>;
-        type PRFw8 = ShakePRFtoF<HASH_LEN_FE_W8>;
+        type PRFw8 = ShakePRFtoF<BabyBear, HASH_LEN_FE_W8>;
         type IEw8 = WinternitzEncoding<MHw8, CHUNK_SIZE_W8, NUM_CHUNKS_CHECKSUM_W8>;
         /// Instantiation with Lifetime 2^20, Winternitz encoding, chunk size w = 8
         pub type SIGWinternitzLifetime20W8 =
@@ -580,6 +586,8 @@ pub mod lifetime_2_to_the_20 {
     }
     /// Instantiations based on the target sum encoding
     pub mod target_sum {
+        use p3_baby_bear::BabyBear;
+
         use crate::{
             inc_encoding::target_sum::TargetSumEncoding,
             signature::generalized_xmss::GeneralizedXMSSSignatureScheme,
@@ -613,7 +621,7 @@ pub mod lifetime_2_to_the_20 {
         >;
         type THw1 =
             PoseidonTweakHash<PARAMETER_LEN, HASH_LEN_FE, TWEAK_LEN_FE, CAPACITY, NUM_CHUNKS_W1>;
-        type PRFw1 = ShakePRFtoF<HASH_LEN_FE>;
+        type PRFw1 = ShakePRFtoF<BabyBear, HASH_LEN_FE>;
         type IEw1<const TARGET_SUM: usize> = TargetSumEncoding<MHw1, TARGET_SUM>;
         /// Instantiation with Lifetime 2^20, Target sum encoding, chunk size w = 1,
         /// and target sum set at expectation
@@ -639,7 +647,7 @@ pub mod lifetime_2_to_the_20 {
         >;
         type THw2 =
             PoseidonTweakHash<PARAMETER_LEN, HASH_LEN_FE, TWEAK_LEN_FE, CAPACITY, NUM_CHUNKS_W2>;
-        type PRFw2 = ShakePRFtoF<HASH_LEN_FE>;
+        type PRFw2 = ShakePRFtoF<BabyBear, HASH_LEN_FE>;
         type IEw2<const TARGET_SUM: usize> = TargetSumEncoding<MHw2, TARGET_SUM>;
         /// Instantiation with Lifetime 2^20, Target sum encoding, chunk size w = 2,
         /// and target sum set at expectation
@@ -665,7 +673,7 @@ pub mod lifetime_2_to_the_20 {
         >;
         type THw4 =
             PoseidonTweakHash<PARAMETER_LEN, HASH_LEN_FE, TWEAK_LEN_FE, CAPACITY, NUM_CHUNKS_W4>;
-        type PRFw4 = ShakePRFtoF<HASH_LEN_FE>;
+        type PRFw4 = ShakePRFtoF<BabyBear, HASH_LEN_FE>;
         type IEw4<const TARGET_SUM: usize> = TargetSumEncoding<MHw4, TARGET_SUM>;
         /// Instantiation with Lifetime 2^20, Target sum encoding, chunk size w = 4,
         /// and target sum set at expectation
@@ -692,7 +700,7 @@ pub mod lifetime_2_to_the_20 {
         >;
         type THw8 =
             PoseidonTweakHash<PARAMETER_LEN, HASH_LEN_FE_W8, TWEAK_LEN_FE, CAPACITY, NUM_CHUNKS_W8>;
-        type PRFw8 = ShakePRFtoF<HASH_LEN_FE_W8>;
+        type PRFw8 = ShakePRFtoF<BabyBear, HASH_LEN_FE_W8>;
         type IEw8<const TARGET_SUM: usize> = TargetSumEncoding<MHw8, TARGET_SUM>;
         /// Instantiation with Lifetime 2^20, Target sum encoding, chunk size w = 8,
         /// and target sum set at expectation

--- a/src/signature/generalized_xmss/instantiations_poseidon_top_level.rs
+++ b/src/signature/generalized_xmss/instantiations_poseidon_top_level.rs
@@ -1,5 +1,7 @@
 /// Instantiations with Lifetime 2^18
 pub mod lifetime_2_to_the_18 {
+    use p3_baby_bear::BabyBear;
+
     use crate::{
         inc_encoding::target_sum::TargetSumEncoding,
         signature::generalized_xmss::GeneralizedXMSSSignatureScheme,
@@ -40,7 +42,7 @@ pub mod lifetime_2_to_the_18 {
         RAND_LEN_FE,
     >;
     type TH = PoseidonTweakHash<PARAMETER_LEN, HASH_LEN_FE, TWEAK_LEN_FE, CAPACITY, DIMENSION>;
-    type PRF = ShakePRFtoF<HASH_LEN_FE>;
+    type PRF = ShakePRFtoF<BabyBear, HASH_LEN_FE>;
     type IE = TargetSumEncoding<MH, TARGET_SUM>;
 
     pub type SIGTopLevelTargetSumLifetime18Dim64Base8 =
@@ -84,6 +86,8 @@ pub mod lifetime_2_to_the_32 {
     /// Instantiation optimized for verification hashing
     pub mod hashing_optimized {
 
+        use p3_baby_bear::BabyBear;
+
         use crate::{
             inc_encoding::target_sum::TargetSumEncoding,
             signature::generalized_xmss::GeneralizedXMSSSignatureScheme,
@@ -125,7 +129,7 @@ pub mod lifetime_2_to_the_32 {
             RAND_LEN_FE,
         >;
         type TH = PoseidonTweakHash<PARAMETER_LEN, HASH_LEN_FE, TWEAK_LEN_FE, CAPACITY, DIMENSION>;
-        type PRF = ShakePRFtoF<HASH_LEN_FE>;
+        type PRF = ShakePRFtoF<BabyBear, HASH_LEN_FE>;
         type IE = TargetSumEncoding<MH, TARGET_SUM>;
 
         pub type SIGTopLevelTargetSumLifetime32Dim64Base8 =
@@ -164,6 +168,8 @@ pub mod lifetime_2_to_the_32 {
 
     /// Instantiation that provides a trade-off between hashing and size
     pub mod tradeoff {
+
+        use p3_baby_bear::BabyBear;
 
         use crate::{
             inc_encoding::target_sum::TargetSumEncoding,
@@ -206,7 +212,7 @@ pub mod lifetime_2_to_the_32 {
             RAND_LEN_FE,
         >;
         type TH = PoseidonTweakHash<PARAMETER_LEN, HASH_LEN_FE, TWEAK_LEN_FE, CAPACITY, DIMENSION>;
-        type PRF = ShakePRFtoF<HASH_LEN_FE>;
+        type PRF = ShakePRFtoF<BabyBear, HASH_LEN_FE>;
         type IE = TargetSumEncoding<MH, TARGET_SUM>;
 
         pub type SIGTopLevelTargetSumLifetime32Dim48Base10 =
@@ -245,6 +251,8 @@ pub mod lifetime_2_to_the_32 {
 
     /// Instantiation optimized for signature size
     pub mod size_optimized {
+        use p3_baby_bear::BabyBear;
+
         use crate::{
             inc_encoding::target_sum::TargetSumEncoding,
             signature::generalized_xmss::GeneralizedXMSSSignatureScheme,
@@ -286,7 +294,7 @@ pub mod lifetime_2_to_the_32 {
             RAND_LEN_FE,
         >;
         type TH = PoseidonTweakHash<PARAMETER_LEN, HASH_LEN_FE, TWEAK_LEN_FE, CAPACITY, DIMENSION>;
-        type PRF = ShakePRFtoF<HASH_LEN_FE>;
+        type PRF = ShakePRFtoF<BabyBear, HASH_LEN_FE>;
         type IE = TargetSumEncoding<MH, TARGET_SUM>;
 
         pub type SIGTopLevelTargetSumLifetime32Dim32Base26 =

--- a/src/symmetric/message_hash/top_level_poseidon.rs
+++ b/src/symmetric/message_hash/top_level_poseidon.rs
@@ -141,8 +141,8 @@ where
         let perm = default_babybear_poseidon2_24();
 
         // first, encode the message and the epoch as field elements
-        let message_fe = encode_message::<MSG_LEN_FE>(message);
-        let epoch_fe = encode_epoch::<TWEAK_LEN_FE>(epoch);
+        let message_fe = encode_message::<F, MSG_LEN_FE>(message);
+        let epoch_fe = encode_epoch::<F, TWEAK_LEN_FE>(epoch);
 
         // now, invoke Poseidon a few times, to get field elements
         let mut pos_outputs = [F::ZERO; POS_OUTPUT_LEN_FE];
@@ -161,7 +161,7 @@ where
                 .collect();
 
             let iteration_pos_output =
-                poseidon_compress::<_, 24, POS_OUTPUT_LEN_PER_INV_FE>(&perm, &combined_input);
+                poseidon_compress::<_, _, 24, POS_OUTPUT_LEN_PER_INV_FE>(&perm, &combined_input);
 
             pos_outputs[i * POS_OUTPUT_LEN_PER_INV_FE..(i + 1) * POS_OUTPUT_LEN_PER_INV_FE]
                 .copy_from_slice(&iteration_pos_output);

--- a/src/symmetric/prf/shake_to_field.rs
+++ b/src/symmetric/prf/shake_to_field.rs
@@ -1,6 +1,6 @@
+use std::marker::PhantomData;
+
 use super::Pseudorandom;
-use p3_baby_bear::BabyBear;
-use p3_field::PrimeCharacteristicRing;
 use p3_field::PrimeField64;
 use serde::{Serialize, de::DeserializeOwned};
 use sha3::{
@@ -9,8 +9,6 @@ use sha3::{
 };
 
 use num_bigint::BigUint;
-
-type F = BabyBear;
 
 // Number of pseudorandom bytes to generate one pseudorandom field element
 const PRF_BYTES_PER_FE: usize = 8;
@@ -23,10 +21,11 @@ const PRF_DOMAIN_SEP: [u8; 16] = [
 /// A pseudorandom function mapping to field elements.
 /// It is implemented using Shake128.
 /// It outputs OUTPUT_LENGTH_FE many field elements.
-pub struct ShakePRFtoF<const OUTPUT_LENGTH_FE: usize>;
+pub struct ShakePRFtoF<F, const OUTPUT_LENGTH_FE: usize>(PhantomData<F>);
 
-impl<const OUTPUT_LENGTH_FE: usize> Pseudorandom for ShakePRFtoF<OUTPUT_LENGTH_FE>
+impl<F, const OUTPUT_LENGTH_FE: usize> Pseudorandom for ShakePRFtoF<F, OUTPUT_LENGTH_FE>
 where
+    F: PrimeField64,
     [F; OUTPUT_LENGTH_FE]: Serialize + DeserializeOwned,
 {
     type Key = [u8; KEY_LENGTH];
@@ -79,13 +78,15 @@ where
 
 #[cfg(test)]
 mod tests {
+    use p3_baby_bear::BabyBear;
+
     use super::*;
 
     #[test]
     fn test_shake_to_field_prf_key_not_all_same() {
         const K: usize = 10;
         const OUTPUT_LEN: usize = 4;
-        type PRF = ShakePRFtoF<OUTPUT_LEN>;
+        type PRF = ShakePRFtoF<BabyBear, OUTPUT_LEN>;
 
         let mut rng = rand::rng();
         let mut all_same_count = 0;


### PR DESCRIPTION
This is a proposal with the goal of making the field generic, meaning that in the future, we should be able to simply modify a single parameter in the code to select the field, whether it's BabyBear, KoalaBear, or maybe Goldilocks, if we want to run some tests.

I propose this first step, which aims to introduce small `F` generics in small util methods, to get closer to our goal.

To ensure that all the code is generic, we'll need to think about an intelligent way to handle Poseidon2 permutations generically, knowing that their initialization is not constant time, so it should be done at runtime. But this is an issue that we can address in a future PR, knowing that this one seems inevitable to me.