### PR TITLE
BabyBear: define type in lib file

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,13 @@
+use p3_baby_bear::BabyBear;
+
 /// Message length in bytes, for messages that we want to sign.
 pub const MESSAGE_LENGTH: usize = 32;
 
 pub const TWEAK_SEPARATOR_FOR_MESSAGE_HASH: u8 = 0x02;
 pub const TWEAK_SEPARATOR_FOR_TREE_HASH: u8 = 0x01;
 pub const TWEAK_SEPARATOR_FOR_CHAIN_HASH: u8 = 0x00;
+
+type F = BabyBear;
 
 pub mod hypercube;
 pub mod inc_encoding;

--- a/src/symmetric/message_hash/poseidon.rs
+++ b/src/symmetric/message_hash/poseidon.rs
@@ -1,5 +1,4 @@
 use num_bigint::BigUint;
-use p3_baby_bear::BabyBear;
 use p3_baby_bear::default_babybear_poseidon2_24;
 use p3_field::PrimeCharacteristicRing;
 use p3_field::PrimeField;
@@ -7,11 +6,10 @@ use p3_field::PrimeField64;
 use serde::{Serialize, de::DeserializeOwned};
 
 use super::MessageHash;
+use crate::F;
 use crate::MESSAGE_LENGTH;
 use crate::TWEAK_SEPARATOR_FOR_MESSAGE_HASH;
 use crate::symmetric::tweak_hash::poseidon::poseidon_compress;
-
-type F = BabyBear;
 
 /// Function to encode a message as an array of field elements
 pub(crate) fn encode_message<const MSG_LEN_FE: usize>(

--- a/src/symmetric/message_hash/top_level_poseidon.rs
+++ b/src/symmetric/message_hash/top_level_poseidon.rs
@@ -1,5 +1,4 @@
 use num_bigint::BigUint;
-use p3_baby_bear::BabyBear;
 use p3_baby_bear::default_babybear_poseidon2_24;
 use p3_field::PrimeCharacteristicRing;
 use p3_field::PrimeField;
@@ -9,13 +8,12 @@ use serde::{Serialize, de::DeserializeOwned};
 use super::MessageHash;
 use super::poseidon::encode_epoch;
 use super::poseidon::encode_message;
+use crate::F;
 use crate::MESSAGE_LENGTH;
 use crate::hypercube::hypercube_find_layer;
 use crate::hypercube::hypercube_part_size;
 use crate::hypercube::map_to_vertex;
 use crate::symmetric::tweak_hash::poseidon::poseidon_compress;
-
-type F = BabyBear;
 
 /// Function to make a list of field elements to a vertex in layers 0, ..., FINAL_LAYER
 /// of the hypercube {0,...,BASE-1}^DIMENSION.

--- a/src/symmetric/prf/shake_to_field.rs
+++ b/src/symmetric/prf/shake_to_field.rs
@@ -1,5 +1,6 @@
+use crate::F;
+
 use super::Pseudorandom;
-use p3_baby_bear::BabyBear;
 use p3_field::PrimeCharacteristicRing;
 use p3_field::PrimeField64;
 use serde::{Serialize, de::DeserializeOwned};
@@ -9,8 +10,6 @@ use sha3::{
 };
 
 use num_bigint::BigUint;
-
-type F = BabyBear;
 
 // Number of pseudorandom bytes to generate one pseudorandom field element
 const PRF_BYTES_PER_FE: usize = 8;

--- a/src/symmetric/tweak_hash/poseidon.rs
+++ b/src/symmetric/tweak_hash/poseidon.rs
@@ -1,4 +1,3 @@
-use p3_baby_bear::BabyBear;
 use p3_baby_bear::default_babybear_poseidon2_16;
 use p3_baby_bear::default_babybear_poseidon2_24;
 use p3_field::PrimeCharacteristicRing;
@@ -6,12 +5,11 @@ use p3_field::PrimeField64;
 use p3_symmetric::Permutation;
 use serde::{Serialize, de::DeserializeOwned};
 
+use crate::F;
 use crate::TWEAK_SEPARATOR_FOR_CHAIN_HASH;
 use crate::TWEAK_SEPARATOR_FOR_TREE_HASH;
 
 use super::TweakableHash;
-
-type F = BabyBear;
 
 const DOMAIN_PARAMETERS_LENGTH: usize = 4;
 /// The state width for compressing a single hash in a chain.


### PR DESCRIPTION
To make this easier https://github.com/b-wagn/hash-sig/pull/69 I propose that the field used be defined only once in the code, so that it's easier to make things generic overall.

I don't think there are any special cases where we would need to have multiple different fields in different files, right?

It seems cleaner to have this defined only once, right?