### PR TITLE
poseidon: permutation utils

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
-use p3_baby_bear::BabyBear;
+use p3_baby_bear::{
+    BabyBear, Poseidon2BabyBear, default_babybear_poseidon2_16, default_babybear_poseidon2_24,
+};
 
 /// Message length in bytes, for messages that we want to sign.
 pub const MESSAGE_LENGTH: usize = 32;
@@ -13,3 +15,13 @@ pub mod hypercube;
 pub mod inc_encoding;
 pub mod signature;
 pub mod symmetric;
+
+/// Poseidon2 permutation (width 24)
+pub(crate) fn poseidon2_24() -> Poseidon2BabyBear<24> {
+    default_babybear_poseidon2_24()
+}
+
+/// Poseidon2 permutation (width 16)
+pub(crate) fn poseidon2_16() -> Poseidon2BabyBear<16> {
+    default_babybear_poseidon2_16()
+}

--- a/src/symmetric/message_hash/poseidon.rs
+++ b/src/symmetric/message_hash/poseidon.rs
@@ -1,5 +1,4 @@
 use num_bigint::BigUint;
-use p3_baby_bear::default_babybear_poseidon2_24;
 use p3_field::PrimeCharacteristicRing;
 use p3_field::PrimeField;
 use p3_field::PrimeField64;
@@ -9,6 +8,7 @@ use super::MessageHash;
 use crate::F;
 use crate::MESSAGE_LENGTH;
 use crate::TWEAK_SEPARATOR_FOR_MESSAGE_HASH;
+use crate::poseidon2_24;
 use crate::symmetric::tweak_hash::poseidon::poseidon_compress;
 
 /// Function to encode a message as an array of field elements
@@ -151,7 +151,7 @@ where
         message: &[u8; MESSAGE_LENGTH],
     ) -> Vec<u8> {
         // Get the default, pre-configured Poseidon2 instance from Plonky3.
-        let perm = default_babybear_poseidon2_24();
+        let perm = poseidon2_24();
 
         // first, encode the message and the epoch as field elements
         let message_fe = encode_message::<MSG_LEN_FE>(message);

--- a/src/symmetric/message_hash/top_level_poseidon.rs
+++ b/src/symmetric/message_hash/top_level_poseidon.rs
@@ -1,5 +1,4 @@
 use num_bigint::BigUint;
-use p3_baby_bear::default_babybear_poseidon2_24;
 use p3_field::PrimeCharacteristicRing;
 use p3_field::PrimeField;
 use p3_field::PrimeField64;
@@ -13,6 +12,7 @@ use crate::MESSAGE_LENGTH;
 use crate::hypercube::hypercube_find_layer;
 use crate::hypercube::hypercube_part_size;
 use crate::hypercube::map_to_vertex;
+use crate::poseidon2_24;
 use crate::symmetric::tweak_hash::poseidon::poseidon_compress;
 
 /// Function to make a list of field elements to a vertex in layers 0, ..., FINAL_LAYER
@@ -136,7 +136,7 @@ where
         randomness: &Self::Randomness,
         message: &[u8; MESSAGE_LENGTH],
     ) -> Vec<u8> {
-        let perm = default_babybear_poseidon2_24();
+        let perm = poseidon2_24();
 
         // first, encode the message and the epoch as field elements
         let message_fe = encode_message::<MSG_LEN_FE>(message);

--- a/src/symmetric/tweak_hash/poseidon.rs
+++ b/src/symmetric/tweak_hash/poseidon.rs
@@ -1,5 +1,3 @@
-use p3_baby_bear::default_babybear_poseidon2_16;
-use p3_baby_bear::default_babybear_poseidon2_24;
 use p3_field::PrimeCharacteristicRing;
 use p3_field::PrimeField64;
 use p3_symmetric::Permutation;
@@ -8,6 +6,8 @@ use serde::{Serialize, de::DeserializeOwned};
 use crate::F;
 use crate::TWEAK_SEPARATOR_FOR_CHAIN_HASH;
 use crate::TWEAK_SEPARATOR_FOR_TREE_HASH;
+use crate::poseidon2_16;
+use crate::poseidon2_24;
 
 use super::TweakableHash;
 
@@ -291,7 +291,7 @@ where
         match message {
             [single] => {
                 // we compress parameter, tweak, message
-                let perm = default_babybear_poseidon2_16();
+                let perm = poseidon2_16();
                 let combined_input: Vec<F> = parameter
                     .iter()
                     .chain(tweak_fe.iter())
@@ -303,7 +303,7 @@ where
 
             [left, right] => {
                 // we compress parameter, tweak, message (now containing two parts)
-                let perm = default_babybear_poseidon2_24();
+                let perm = poseidon2_24();
                 let combined_input: Vec<F> = parameter
                     .iter()
                     .chain(tweak_fe.iter())
@@ -316,7 +316,7 @@ where
 
             _ if message.len() > 2 => {
                 // Hashing many blocks
-                let perm = default_babybear_poseidon2_24();
+                let perm = poseidon2_24();
                 let combined_input: Vec<F> = parameter
                     .iter()
                     .chain(tweak_fe.iter())


### PR DESCRIPTION
This way, if we want to change the field (for example, switch to KoalaBear), we just have to modify the elements of the lib.rs file and nothing else in the codebase.