### PR TITLE
Add Rust toolchain and formatting configuration files

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.87"
+components = ["rustfmt", "clippy"]
+

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+max_width = 100
+newline_style = "Unix"
+use_small_heuristics = "Max"


### PR DESCRIPTION
- Introduced `rust-toolchain.toml` to specify Rust version and components (rustfmt, clippy).
- Added `rustfmt.toml` for custom formatting settings including max width and newline style.